### PR TITLE
chore: update branch references after master -> main rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "v[0-9].[0-9]+.[0-9]+" # v1.0.0
       #- "v[0-9].[0-9]+.[0-9]+-rc[0-9]+" # v1.0.0-rc01
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - README.md
       - CONTRIBUTING.md

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ on:
     branches: ["*"]
     #paths-ignore:
   push:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: validate-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,4 +90,4 @@ PRs land in the **first** matching category, so order labels by importance (e.g.
 
 This project also includes the necessary tools to automate the release of the module via GitHub Actions. The file [release.yml](.github/workflows/release.yml) handles this task.
 
-To create a new release of the module, first update the module manifest with the necessary version number and commit that to the master branch. Then, create a new tag with the same version number and push it to GitHub. This will start the build process and publish a new version of the module to the repo.
+To create a new release of the module, first update the module manifest with the necessary version number and commit that to the main branch. Then, create a new tag with the same version number and push it to GitHub. This will start the build process and publish a new version of the module to the repo.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SecurityTools
 
-[![validate](https://github.com/johnsarie27/SecurityTools/actions/workflows/validate.yml/badge.svg?branch=master)](https://github.com/johnsarie27/SecurityTools/actions/workflows/validate.yml)
+[![validate](https://github.com/johnsarie27/SecurityTools/actions/workflows/validate.yml/badge.svg?branch=main)](https://github.com/johnsarie27/SecurityTools/actions/workflows/validate.yml)
 [![release](https://github.com/johnsarie27/SecurityTools/actions/workflows/release.yml/badge.svg)](https://github.com/johnsarie27/SecurityTools/actions/workflows/release.yml)
 [![License](https://img.shields.io/github/license/johnsarie27/SecurityTools.svg)](LICENSE)
 

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -189,7 +189,7 @@
             Tags       = @('Security', 'Tools')
 
             # A URL to the license for this module.
-            LicenseUri = 'https://github.com/johnsarie27/SecurityTools/blob/master/LICENSE'
+            LicenseUri = 'https://github.com/johnsarie27/SecurityTools/blob/main/LICENSE'
 
             # A URL to the main website for this project.
             ProjectUri = 'https://github.com/johnsarie27/SecurityTools'


### PR DESCRIPTION
Follow-up to the GitHub default-branch rename from `master` to `main`. Updates in-repo references so workflows trigger correctly and the validate badge resolves.

## Changes

- `.github/workflows/release.yml` — push trigger `branches: [main]`
- `.github/workflows/validate.yml` — push trigger `branches: [main]`
- `README.md` — validate badge URL `?branch=main`
- `CONTRIBUTING.md` — release-section wording
- `SecurityTools.psd1` — `LicenseUri` `/blob/master/` → `/blob/main/`

External `master` references in `Tests/Common`, `Private/Invoke-DiskCleanup`, and `Tests/Unit/*.tests.ps1` are links to upstream juneb/adbertram/PowerShell repositories and are intentionally left as-is.