### PR TITLE
fix(Public): standardize comment-based help across all functions (closes #97)

### DIFF
--- a/Public/Compare-List.ps1
+++ b/Public/Compare-List.ps1
@@ -24,6 +24,7 @@ function Compare-List {
     .EXAMPLE
         PS C:\> Compare-List -ListA $ListA -ListB $ListB
     .NOTES
+        Status: Stable
         Remove $compSheet section and have use Import-Csv with two lists?
     #>
     [CmdletBinding(DefaultParameterSetName = "__list")]

--- a/Public/Compress-URL.ps1
+++ b/Public/Compress-URL.ps1
@@ -16,11 +16,7 @@ function Compress-URL {
         PS C:\> Compress-URL -URL 'https://www.google.com'
         Get a shortened URL for 'https://www.google.com'
     .NOTES
-        Name: Compress-URL
-        Author: Justin Johns
-        Version: 0.1.0 | Last Edit: 2024-01-28
-        - 0.1.0 - (2024-01-28) Initial version
-        General notes
+        Status: Stable
         https://onesimpleapi.com/docs/url-shortener
     #>
     [CmdletBinding()]

--- a/Public/Convert-Epoch.ps1
+++ b/Public/Convert-Epoch.ps1
@@ -18,7 +18,7 @@ function Convert-Epoch {
         PS C:\> Convert-Epoch -Seconds 1618614176
         Converts epoch time to date/time object
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding(DefaultParameterSetName = '__dt')]
     Param(

--- a/Public/Convert-Hexadecimal.ps1
+++ b/Public/Convert-Hexadecimal.ps1
@@ -16,12 +16,7 @@ function Convert-Hexadecimal {
         PS C:\> Convert-Hexadecimal 4248
         Converts decimal value of 4248 to hexadecimal value
     .NOTES
-        Name:     Convert-Hexadecimal
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2022-07-16
-        - <VersionNotes> (or remove this line if no version notes)
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding(DefaultParameterSetName = '__dcm')]
     [OutputType('System.String')]

--- a/Public/Convert-SecureKey.ps1
+++ b/Public/Convert-SecureKey.ps1
@@ -28,6 +28,7 @@ function Convert-SecureKey {
         -- EXAMPLE 2 --
         PS C:\> Convert-SecureKey -Path C:\Store\Credentials.xml
     .NOTES
+        Status: Stable
         It appears that the Clixml file is locked to the user and computer where
         it was created. It cannot be accessed by another user or computer. The
         article below has more information based on a different Cmdlet.

--- a/Public/Convert-TimeZone.ps1
+++ b/Public/Convert-TimeZone.ps1
@@ -18,6 +18,7 @@ function Convert-TimeZone {
         PS C:\> Convert-TimeZone -Time "2019-06-01 10:00 PM" -Source UTC -Target Eastern
         Convert "2019-06-01 10:00 PM" from UTC to Eastern time zone.
     .NOTES
+        Status: Stable
         [DateTime]::UtcNow
         $DateTimeObject.ToLocalTime()
         $DateTimeObject.ToUniversalTime()

--- a/Public/ConvertFrom-Encoding.ps1
+++ b/Public/ConvertFrom-Encoding.ps1
@@ -16,12 +16,7 @@ function ConvertFrom-Encoding {
         PS C:\> ConvertFrom-Encoding -String $encodedString
         Decode $encodedString from Base64
     .NOTES
-        Name: ConvertFrom-Encoding
-        Author: Justin Johns
-        Version: 0.1.1 | Last Edit: 2022-01-11 [0.1.1]
-        - Changed class used to perform URL decoding
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     [OutputType('System.String')]

--- a/Public/ConvertFrom-GZipString.ps1
+++ b/Public/ConvertFrom-GZipString.ps1
@@ -11,17 +11,12 @@ function ConvertFrom-GZipString {
     .OUTPUTS
         System.String.
     .EXAMPLE
-        $compressedString | ConvertFrom-GZipString
+        PS C:\> $compressedString | ConvertFrom-GZipString
+        Decompresses and returns the original string from a Base64 GZipped string.
     .LINK
         ConvertTo-GZipString
     .NOTES
-        Name: ConvertFrom-GZipString
-        Author: Justin Johns
-        Version: 0.1.1 | Last Edit: 2022-01-27 [0.1.1]
-        - modified parameter to accept array of string
-        - changed Foreach-Object to foreach command
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://www.dorkbrain.com/docs/2017/09/02/gzip-in-powershell/
     #>
     [CmdletBinding()]

--- a/Public/ConvertFrom-IISLog.ps1
+++ b/Public/ConvertFrom-IISLog.ps1
@@ -14,16 +14,7 @@ function ConvertFrom-IISLog {
         PS C:\> ConvertFrom-IISLog -Path C:\logs\myLog.log
         Converts log data into objects
     .NOTES
-        Name:     ConvertFrom-IISLog
-        Author:   Justin Johns
-        Version:  0.1.4 | Last Edit: 2022-11-13
-        - 0.1.4 - Code clean
-        - 0.1.3 - Added pipeline input and ordered properties
-        - 0.1.2 - Get headers from log file
-        - 0.1.1 - Updated code to skip header rows
-        - 0.1.0 - Initial version
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/ConvertTo-Encoding.ps1
+++ b/Public/ConvertTo-Encoding.ps1
@@ -16,12 +16,7 @@ function ConvertTo-Encoding {
         PS C:\> ConvertTo-Encoding -String 'https://google.com/' -Encoding URL
         URL encode 'https://google.com/'
     .NOTES
-        Name: ConvertTo-Encoding
-        Author: Justin Johns
-        Version: 0.1.1 | Last Edit: 2022-01-11 [0.1.1]
-        - Changed class used to perform URL encoding
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     [OutputType('System.String')]

--- a/Public/ConvertTo-FlatObject.ps1
+++ b/Public/ConvertTo-FlatObject.ps1
@@ -26,14 +26,10 @@ function ConvertTo-FlatObject {
     .OUTPUTS
         System.Object.
     .EXAMPLE
-        PS C:\> <example usage>
-        Explanation of what the example does
+        PS C:\> Get-Process | ConvertTo-FlatObject
+        Flattens all process objects into single-level objects with dot-separated property names.
     .NOTES
-        Name:     ConvertTo-FlatObject
-        Version:  0.1.0 | Last Edit: 2022-08-17
-        - 0.1.0 - Initial version
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         Based on the articles below:
         https://powersnippets.com/convertto-flatobject/
         https://github.com/EvotecIT/PSSharedGoods/blob/master/Public/Converts/ConvertTo-FlatObject.ps1

--- a/Public/ConvertTo-Hex.ps1
+++ b/Public/ConvertTo-Hex.ps1
@@ -11,15 +11,10 @@ function ConvertTo-Hex {
     .OUTPUTS
         System.Management.Automation.PSCustomObject.
     .EXAMPLE
-        PS C:\> <example usage>
-        Explanation of what the example does
+        PS C:\> ConvertTo-Hex -Character 'A'
+        Returns the hexadecimal value 0x41 for the character 'A'.
     .NOTES
-        Name:     ConvertTo-Hex
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2023-10-20
-        - 0.1.0 - Initial version
-
-        Comments: <Comment(s)>
+        Status: Stable
         TO CONVERT FROM HEX TO CHAR USE THE CODE BELOW
         [System.Char] 0x21
     #>

--- a/Public/ConvertTo-MarkdownTable.ps1
+++ b/Public/ConvertTo-MarkdownTable.ps1
@@ -15,13 +15,7 @@ function ConvertTo-MarkdownTable {
         PS C:\> $svc | Select-Object -First 5 | ConvertTo-MarkdownTable
         Converts the first 5 services to a Markdown table
     .NOTES
-        Name:     ConvertTo-MarkDownTable
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2022-09-28
-        - 0.1.0 - Initial version
-        - 0.1.1 - Added spaces around text
-        Comments: <Comment(s)>
-        General notes:
+        Status: Stable
         https://stackoverflow.com/questions/69010143/convert-powershell-output-to-a-markdown-file
     #>
     [CmdletBinding()]

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -16,11 +16,7 @@ function Expand-GZip {
         PS C:\> Expand-GZip -Path C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06.gz
         Extracts file to C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06
     .NOTES
-        Name:     Expand-GZip
-        Author:   RiffyRiot
-        Version:  0.1.2 | Last Edit: 2025-06-13
-        - see commit history for version history
-        General Notes:
+        Status: Stable
         https://social.technet.microsoft.com/Forums/windowsserver/en-US/5aa53fef-5229-4313-a035-8b3a38ab93f5/unzip-gz-files-using-powershell?forum=winserverpowershell
     #>
     [CmdletBinding()]

--- a/Public/Expand-URL.ps1
+++ b/Public/Expand-URL.ps1
@@ -16,12 +16,7 @@ function Expand-URL {
         PS C:\> Expand-URL -URL 'https://tinyurl.com/RedlandsStake' # https://t.co/Q0uEt49I5D
         Show destination URL target for bitly shortened or redirected URL
     .NOTES
-        Name: Expand-URL
-        Author: Justin Johns
-        Version: 0.1.0 | Last Edit: 2024-01-28 [0.1.1]
-        - 0.1.1 - (2024-01-28) Moved query arguments to the request body
-        - 0.1.0 - (2022-01-10) Initial version
-        General notes
+        Status: Stable
         https://onesimpleapi.com/docs/url-unshorten
     #>
     [CmdletBinding()]

--- a/Public/Export-NPMAudit.ps1
+++ b/Public/Export-NPMAudit.ps1
@@ -15,9 +15,9 @@ function Export-NPMAudit {
         None.
     .EXAMPLE
         PS C:\> Export-NPMAudit -Path C:\temp\npmaudit.json
-        Explanation of what the example does
+        Exports the NPM audit results from the provided JSON file to an Excel workbook on the desktop.
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Export-SQLVAReport.ps1
+++ b/Public/Export-SQLVAReport.ps1
@@ -22,7 +22,7 @@ function Export-SQLVAReport {
         This exports a scan report using SQL Vulnerability Assessment tool for the master
         database on MySQLServer using the corresponding baseline file in C:\Baselines.
     .NOTES
-        General notes
+        Status: Stable
         https://docs.microsoft.com/en-us/sql/relational-databases/security/sql-vulnerability-assessment?view=sql-server-2017
     #>
     [CmdletBinding()]

--- a/Public/Export-SQLVAReportAggregate.ps1
+++ b/Public/Export-SQLVAReportAggregate.ps1
@@ -21,7 +21,7 @@ function Export-SQLVAReportAggregate {
         PS C:\> Export-SQLVAReportAggregate -InputPath (Get-ChildItem C:\MyScans).FullName
         Combine all scans in C:\MyScans folder into a single report and output to the desktop.
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding(DefaultParameterSetName = 'folder')]
     Param(

--- a/Public/Export-ScanReportAggregate.ps1
+++ b/Public/Export-ScanReportAggregate.ps1
@@ -30,6 +30,7 @@ function Export-ScanReportAggregate {
         report for easy review.
     .NOTES
         Status: Stable
+    #>
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)]

--- a/Public/Export-ScanReportAggregate.ps1
+++ b/Public/Export-ScanReportAggregate.ps1
@@ -28,7 +28,8 @@ function Export-ScanReportAggregate {
         PS C:\> Export-ScanReportAggregate -SystemScan $Sys -AlertLogicWebScan $Web
         Merge and aggregate data from $Sys and $Web scans into a pre-filtered
         report for easy review.
-    #>
+    .NOTES
+        Status: Stable
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)]

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -28,6 +28,7 @@ function Export-ScanReportSummary {
         spreadsheet file.
     .NOTES
         Status: Stable
+    #>
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)]

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -26,7 +26,8 @@ function Export-ScanReportSummary {
         PS C:\> Export-ScanReportSummary -NessusSystemScan $Sys -AlertLogicWebScan $Web
         Merge and aggregate data from $Sys and $Web scans and return an Excel
         spreadsheet file.
-    #>
+    .NOTES
+        Status: Stable
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)]

--- a/Public/Export-VeracodeReport.ps1
+++ b/Public/Export-VeracodeReport.ps1
@@ -14,10 +14,10 @@ function Export-VeracodeReport {
     .OUTPUTS
         None.
     .EXAMPLE
-        PS C:\> <example usage>
-        Explanation of what the example does
+        PS C:\> Export-VeracodeReport -VeracodeXML C:\Reports\scan.xml -OutputDirectory C:\Reports
+        Exports the Veracode scan results from scan.xml to an Excel workbook in C:\Reports.
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Export-WebScan.ps1
+++ b/Public/Export-WebScan.ps1
@@ -17,7 +17,7 @@ function Export-WebScan {
         PS C:\> Export-WebScan -Path C:\myReport.xml
         Processes the Acunetix XML report and produces an Excel Spreadsheet of the results
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Find-LANHost.ps1
+++ b/Public/Find-LANHost.ps1
@@ -11,17 +11,17 @@ function Find-LANHost {
     .PARAMETER ClearARPCache
         Clear ARP cache before scanning
     .INPUTS
-        none.
+        None.
     .OUTPUTS
         System.Object.
     .EXAMPLE
-        PS C:\> $ips = 1..254 | % {"10.250.1.$_"}; Find-LANHost -IP $ips
-        Explanation of what the example does
+        PS C:\> $ips = 1..254 | ForEach-Object { "10.250.1.$_" }; Find-LANHost -IP $ips
+        Scans all 254 hosts on the 10.250.1.0/24 subnet and returns those with active ARP entries.
     .NOTES
-        General notes
+        Status: Stable
         https://xkln.net/blog/layer-2-host-discovery-with-powershell-in-under-a-second/
     #>
-    [Cmdletbinding()]
+    [CmdletBinding()]
     Param (
         [Parameter(Mandatory, Position = 1, HelpMessage = 'IP addresses to scan')]
         [System.String[]] $IP,

--- a/Public/Find-ServerPendingReboot.ps1
+++ b/Public/Find-ServerPendingReboot.ps1
@@ -6,22 +6,16 @@
         Check if a server is pending reboot
     .PARAMETER ComputerName
         Gets the server reboot status on the specified computer.
+    .INPUTS
+        System.String.
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject.
     .EXAMPLE
-        C:\PS> C:\Script\FindServerIsPendingReboot.ps1 -ComputerName "WIN-VU0S8","WIN-FJ6FH","WIN-FJDSH","WIN-FG3FH"
-
-        ComputerName                                          RebootIsPending
-        ------------                                          ---------------
-        WIN-VU0S8                                             False
-        WIN-FJ6FH                                             True
-        WIN-FJDSH                                             True
-        WIN-FG3FH                                             True
-
-        This command will get the reboot status on the specified remote computers.
+        PS C:\> Find-ServerPendingReboot -ComputerName 'WIN-VU0S8', 'WIN-FJ6FH'
+        Returns the pending reboot status for the specified remote computers.
     .NOTES
-        This script was taken from the site listed below. I've made several
-        modifications including formatting for ease of reading.
-
-        https://gallery.technet.microsoft.com/scriptcenter/How-to-check-if-any-4b1e53f2
+        Status: Stable
+        Adapted from https://gallery.technet.microsoft.com/scriptcenter/How-to-check-if-any-4b1e53f2
     #>
     [CmdletBinding()]
     param (

--- a/Public/Find-WinEvent.ps1
+++ b/Public/Find-WinEvent.ps1
@@ -27,11 +27,7 @@ function Find-WinEvent {
         PS C:\> Find-WinEvent.ps1 -Id 8 -ComputerName $Server -Results 10
         Display last 10 RDP Sessions
     .NOTES
-        Name:     Find-WinEvent
-        Author:   Justin Johns
-        Version:  0.1.5 | Last Edit: 2025-11-28
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.diagnostics/get-winevent
     #>
     [CmdletBinding(DefaultParameterSetName = '__lst')]

--- a/Public/Get-ADUserStatus.ps1
+++ b/Public/Get-ADUserStatus.ps1
@@ -14,7 +14,7 @@ function Get-ADUserStatus {
         PS C:\> Get-ADUserStatus -Identity jsmith
         Gets the status information for user jsmith
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-ActiveGatewayUser.ps1
+++ b/Public/Get-ActiveGatewayUser.ps1
@@ -15,7 +15,7 @@ function Get-ActiveGatewayUser {
         PS C:\> Get-ActiveGWUser -CompuaterName Gateway
         Get all users connected through the RDGW "Gateway"
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject])]

--- a/Public/Get-AlternateDataStream.ps1
+++ b/Public/Get-AlternateDataStream.ps1
@@ -21,13 +21,7 @@ function Get-AlternateDataStream {
 
         Gets alternate data streams from all files in current directory with extension .db
     .NOTES
-        Name:     Get-AlternateDataStream
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2022-10-23
-        - 0.1.0 - Initial version
-        Comments: Taken from Jeff Hicks website below
-
-        General notes:
+        Status: Stable
         https://jdhitsolutions.com/blog/scripting/8888/friday-fun-with-powershell-and-alternate-data-streams/
 
         Zone.Identifiers

--- a/Public/Get-CVSSv3BaseScore.ps1
+++ b/Public/Get-CVSSv3BaseScore.ps1
@@ -15,7 +15,7 @@ function Get-CVSSv3BaseScore {
         PS C:\> Get-CVSSv3BaseScore -CVE "CVE-2020-2659"
         Scrapes the NVD NIST page and returns CVSS v3 score for CVE "CVE-2020-2659"
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-CountryCode.ps1
+++ b/Public/Get-CountryCode.ps1
@@ -16,13 +16,7 @@ function Get-CountryCode {
         PS C:\> Get-CountryCode AS
         Returns the country data for "American Somoa"
     .NOTES
-        Name:     Get-CountryCode
-        Author:   Justin Johns
-        Version:  0.1.1 | Last Edit: 2022-08-23
-        - 0.1.0 - Initial version
-        - 0.1.1 - Added global variable to prevent repeated web requests
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://www.iso.org/obp/ui/#search
         https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
         https://datahub.io/core/country-list

--- a/Public/Get-DirectoryReport.ps1
+++ b/Public/Get-DirectoryReport.ps1
@@ -24,6 +24,7 @@ function Get-DirectoryReport {
         Returns a report of all files and folders in C:\MyData that are 4 GB or larger.
     .NOTES
         Status: Stable
+    #>
     [CmdletBinding()]
     [Alias('Get-DirStats')]
     Param(
@@ -43,7 +44,7 @@ function Get-DirectoryReport {
         [System.Management.Automation.SwitchParameter] $NoTotals,
 
         [Parameter(HelpMessage = 'Measure all files of any size')]
-        [switch] $All
+        [System.Management.Automation.SwitchParameter] $All
     )
     Begin {
         # CREATE VARS
@@ -66,38 +67,13 @@ function Get-DirectoryReport {
         }
 
         # SET PROPERTIES
-        $properties = @( @{N = 'Size(GB)'; E = { ($_.Length / 1GB).ToString("0.00") } }, 'FullName' ) #'Directory', 'Name'
+        $properties = @( @{N = 'Size(GB)'; E = { ($_.Length / 1GB).ToString("0.00") } }, 'FullName' )
 
         # GET SELECT PROPERTIES
         [System.Collections.Generic.List[System.Object]] $fileList = $fileList | Select-Object -Property $properties
         #endregion
 
         #region GET FOLDER SIZES
-        <# # LOOP THROUGH ALL DIRECTORIES IN PATH
-        foreach ( $item in (Get-ChildItem -Path $Path -Directory -Force) ) {
-            # GET CHILD MEASUREMENTS FOR FOLDER
-            $folder = Get-ChildItem -Path $item.FullName -Recurse -Force -ErrorAction 0 -ErrorVariable EV |
-            Measure-Object -Property Length -Sum -ErrorAction 0 -ErrorVariable MO
-
-            # SET WARNING VARIABLE
-            if ( $EV -or $MO ) { $warning = $true }
-
-            # EVALUATE FOLDER SIZE
-            if ( ($folder.Sum / 1GB) -gt $SizeInGb ) {
-                # CREATE NEW OBJECT
-                $New = [PSCustomObject] @{
-                    Files      = $folder.Count
-                    'Size(GB)' = ($folder.Sum / 1GB).ToString("0.00")
-                    FolderName = $item.Name
-                }
-
-                # ADD NEW OBJECT TO COLLECTION
-                try { $folderList.Add($New) } catch { }
-            }
-        } #>
-        #endregion
-
-        #region NEW STUFF
         # LOOP ALL SUB-DIRECTORIES IN ORIGINAL PATH
         foreach ( $item in (Get-ChildItem -Path $Path -Directory -Force) ) {
             # SET VARS
@@ -128,12 +104,11 @@ function Get-DirectoryReport {
         # ADD TOTALS
         if ( -not $PSBoundParameters.ContainsKey('NoTotals') ) {
             # CREATE SIZE AND COUNT VARIABLES
-            $fileTotal = 0; $fileCount = 0; $folderNumTotal = 0; $folderSizeTotal = 0
+            $fileTotal = 0; $folderNumTotal = 0; $folderSizeTotal = 0
 
             # LOOP THROUGH ALL FILE OBJECTS
             foreach ( $item in $fileList ) {
                 $fileTotal += $item.'Size(GB)'
-                $fileCount++
             }
             $New = [PSCustomObject] @{
                 'Size(GB)' = $fileTotal

--- a/Public/Get-DirectoryReport.ps1
+++ b/Public/Get-DirectoryReport.ps1
@@ -21,7 +21,9 @@ function Get-DirectoryReport {
         System.Object.
     .EXAMPLE
         PS C:\> Get-DirectoryReport -Path C:\MyData -SizeInGb 4
-    #>
+        Returns a report of all files and folders in C:\MyData that are 4 GB or larger.
+    .NOTES
+        Status: Stable
     [CmdletBinding()]
     [Alias('Get-DirStats')]
     Param(

--- a/Public/Get-DomainRegistration.ps1
+++ b/Public/Get-DomainRegistration.ps1
@@ -16,9 +16,8 @@ function Get-DomainRegistration {
         PS C:\> Get-DomainRegistration -Domain google.com
         Get domain registration info for google.com
     .NOTES
-        General notes
+        Status: Stable
         https://whois.whoisxmlapi.com/documentation/making-requests
-        API token required
         https://rdap.verisign.com/com/v1/domain/<DOMAIN>
         https://domainsrdap.googleapis.com/v1/domain/<DOMAIN>
     #>

--- a/Public/Get-EPSS.ps1
+++ b/Public/Get-EPSS.ps1
@@ -14,11 +14,7 @@ function Get-EPSS {
         PS C:\> Get-EPSS -CVE 'CVE-2022-27225'
         Get the EPSS score for CVE 'CVE-2022-27225'
     .NOTES
-        Name:     Get-EPSS
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2023-12-15
-        - (see commit history)
-        Comments:
+        Status: Stable
         https://www.first.org/epss
         https://www.first.org/epss/api
     #>

--- a/Public/Get-FileHeader.ps1
+++ b/Public/Get-FileHeader.ps1
@@ -17,13 +17,7 @@ function Get-FileHeader {
         PS C:\> Get-FileHeader -Path "C:\myFile.xlsx"
         Returns the first 4 bytes as hex
     .NOTES
-        Name:     Get-FileHeader
-        Author:   Justin Johns
-        Version:  0.1.1 | Last Edit: 2022-08-23
-        - 0.1.0 - Initial version
-        - 0.1.1 - Added parameter for number of bytes to return
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://stackoverflow.com/questions/26194071/recognize-file-types-in-powershell
     #>
     [CmdletBinding()]

--- a/Public/Get-FileInfo.ps1
+++ b/Public/Get-FileInfo.ps1
@@ -14,14 +14,7 @@ function Get-FileInfo {
         PS C:\> Get-FileInfo -Signature '50 4B 03 04'
         Get information on a file with signature '50 4B 03 04'
     .NOTES
-        Name:     Get-FileInfo
-        Author:   Justin Johns
-        Version:  0.1.2 | Last Edit: 2022-08-23
-        - 0.1.0 - Initial version
-        - 0.1.1 - Replaced file with web lookup for file signatures
-        - 0.1.2 - Added global variable to prevent repeated web requests
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://en.wikipedia.org/wiki/List_of_file_signatures
     #>
     [CmdletBinding()]

--- a/Public/Get-FolderSize.ps1
+++ b/Public/Get-FolderSize.ps1
@@ -19,61 +19,33 @@ function Get-FolderSize {
     .OUTPUTS
         None.
     .EXAMPLE
-        Get-FolderSize
+        PS C:\> Get-FolderSize
 
         FolderName                Size(Bytes) Size(MB)     Size(GB)
         ----------                ----------- --------     --------
         $GetCurrent                    193768 0.18 MB      0.00 GB
         $RECYCLE.BIN                 20649823 19.69 MB     0.02 GB
-        $SysReset                    53267392 50.80 MB     0.05 GB
-        Config.Msi                            0.00 MB      0.00 GB
-        Documents and Settings                0.00 MB      0.00 GB
-        Games                     48522184491 46,274.36 MB 45.19 GB
     .EXAMPLE
-        Get-FolderSize -Path 'C:\Program Files'
+        PS C:\> Get-FolderSize -Path 'C:\Program Files'
 
         FolderName                                   Size(Bytes) Size(MB)    Size(GB)
         ----------                                   ----------- --------    --------
         7-Zip                                            4588532 4.38 MB     0.00 GB
         Adobe                                         3567833029 3,402.55 MB 3.32 GB
-        Application Verifier                              353569 0.34 MB     0.00 GB
-        Bonjour                                           615066 0.59 MB     0.00 GB
-        Common Files                                   489183608 466.52 MB   0.46 GB
     .EXAMPLE
-        Get-FolderSize -Path 'C:\Program Files' -FolderName IIS
+        PS C:\> Get-FolderSize -Path 'C:\Program Files' -FolderName IIS
 
         FolderName Size(Bytes) Size(MB) Size(GB)
         ---------- ----------- -------- --------
         IIS            5480411 5.23 MB  0.01 GB
     .EXAMPLE
-        Get-FolderSize
-
-        FolderName Size(GB) Size(MB)
-        ---------- -------- --------
-        Public     0.00 GB  0.00 MB
-        thegn      2.39 GB  2,442.99 MB
+        PS C:\> Get-FolderSize | Sort-Object 'Size(Bytes)' -Descending
+        Returns all top-level folders under C:\ sorted by size descending.
     .EXAMPLE
-        Sort by size descending
-        Get-FolderSize | Sort-Object 'Size(Bytes)' -Descending
-
-        FolderName                Size(Bytes) Size(MB)     Size(GB)
-        ----------                ----------- --------     --------
-        Users                     76280394429 72,746.65 MB 71.04 GB
-        Games                     48522184491 46,274.36 MB 45.19 GB
-        Program Files (x86)       27752593691 26,466.94 MB 25.85 GB
-        Windows                   25351747445 24,177.31 MB 23.61 GB
-    .EXAMPLE
-        Omit folder(s) from being included
-        .\Get-FolderSize -OmitFolder 'C:\Temp','C:\Windows'
+        PS C:\> Get-FolderSize -OmitFolder 'C:\Temp', 'C:\Windows'
+        Returns folder sizes omitting C:\Temp and C:\Windows from the results.
     .NOTES
-        Name:     Get-FolderSize
-        Author:   Ginger Ninja
-        Version:  0.1.1 | Last Edit: 2022-06-02 (Justin Johns)
-        - 0.1.1 - Lots of code clean and consolidation, changed some parameters
-        - 0.1.0 - Updated object creation, removed try/catch that was causing issues
-        - 0.0.5 - Just created!
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://www.gngrninja.com/script-ninja/2016/5/24/powershell-calculating-folder-sizes
     #>
     [CmdletBinding()]

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -14,9 +14,13 @@ function Get-GreyNoiseIPStatus {
         Get-GreyNoiseIPStatus -IPAddress "8.8.8.8" -ApiKey "your_api_key_here"
     .EXAMPLE
         "1.2.3.4", "5.6.7.8" | Get-GreyNoiseIPStatus
+    .INPUTS
+        System.Net.IPAddress[].
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject.
     .NOTES
-        Requires a GreyNoise API key. Free community keys available at https://greynoise.io
-        Prompts/requests for AI to create function: 5
+        Status: Stable
+        https://greynoise.io
     #>
     [CmdletBinding()]
     [OutputType([PSCustomObject])]

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -10,14 +10,16 @@ function Get-GreyNoiseIPStatus {
     .PARAMETER ApiKey
         Your GreyNoise API key. If not provided, attempts to use the
         GREYNOISE_API_KEY environment variable.
-    .EXAMPLE
-        Get-GreyNoiseIPStatus -IPAddress "8.8.8.8" -ApiKey "your_api_key_here"
-    .EXAMPLE
-        "1.2.3.4", "5.6.7.8" | Get-GreyNoiseIPStatus
     .INPUTS
         System.Net.IPAddress[].
     .OUTPUTS
         System.Management.Automation.PSCustomObject.
+    .EXAMPLE
+        PS C:\> Get-GreyNoiseIPStatus -IPAddress "8.8.8.8" -ApiKey "your_api_key_here"
+        Check the threat status of 8.8.8.8 using the provided API key
+    .EXAMPLE
+        PS C:\> "1.2.3.4", "5.6.7.8" | Get-GreyNoiseIPStatus
+        Check the threat status of two IP addresses via pipeline using the GREYNOISE_API_KEY environment variable
     .NOTES
         Status: Stable
         https://greynoise.io

--- a/Public/Get-Ipinfo.ps1
+++ b/Public/Get-Ipinfo.ps1
@@ -7,9 +7,9 @@ function Get-Ipinfo {
     .PARAMETER IPAddress
         IPV4 address
     .INPUTS
-        System.String[].
+        System.Net.IPAddress[].
     .OUTPUTS
-        System.Object[].
+        System.Management.Automation.PSCustomObject.
     .EXAMPLE
         PS C:\> Get-Ipinfo -IPAddress '1.1.1.1'
         Get IP address info for IP '1.1.1.1'
@@ -21,9 +21,7 @@ function Get-Ipinfo {
     [CmdletBinding()]
     Param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, HelpMessage = 'IPV4 address')]
-        [ValidateNotNullOrEmpty()]
-        [ValidatePattern('^(\d{1,3}\.){3}\d{1,3}$')]
-        [System.String[]] $IPAddress
+        [System.Net.IPAddress[]] $IPAddress
     )
     Begin {
         Write-Verbose "Starting $($MyInvocation.Mycommand)"

--- a/Public/Get-Ipinfo.ps1
+++ b/Public/Get-Ipinfo.ps1
@@ -14,7 +14,7 @@ function Get-Ipinfo {
         PS C:\> Get-Ipinfo -IPAddress '1.1.1.1'
         Get IP address info for IP '1.1.1.1'
     .NOTES
-        General notes
+        Status: Stable
         https://ipinfo.io/
         To get more data (e.g., ASN or Company info) a token must be used
     #>

--- a/Public/Get-ItemAge.ps1
+++ b/Public/Get-ItemAge.ps1
@@ -21,8 +21,8 @@ function Get-ItemAge {
         PS C:\> Get-ItemAge -Directory 'D:\Database\logs' -AgeInDays 7
         Get all content details for D:\Database\logs using 7 day measurement
     .NOTES
+        Status: Stable
         https://blogs.technet.microsoft.com/pstips/2017/05/20/display-friendly-file-sizes-in-powershell/
-        https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/invoke-command?view=powershell-6
     #>
     [CmdletBinding()]
     [Alias('Get-DirItemAges')]

--- a/Public/Get-KEVList.ps1
+++ b/Public/Get-KEVList.ps1
@@ -17,19 +17,9 @@ function Get-KEVList {
         PS C:\> Get-KEVList
         Returns an object containing known exploited vulnerability catalog
     .NOTES
-        Name:     Get-KEVList
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2022-08-13
-        - 0.1.0 - Initial version
-        - 0.1.1 - Added dynamic parameter
-        - 0.1.2 - Added output format options CSV, JSON, and Schema
-        Comments: This function was written in order to learn how to use dynamic
-        parameters. The dynamic parameter can be replaced with a single
-        parameter named OutputDirectory.
-        General notes
+        Status: Stable
         https://cyber.dhs.gov/bod/22-01/
         https://www.cisa.gov/known-exploited-vulnerabilities
-        https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-LatestPowerShell.ps1
+++ b/Public/Get-LatestPowerShell.ps1
@@ -1,9 +1,11 @@
 function Get-LatestPowerShell {
     <#
     .SYNOPSIS
-        Short description
+        Download the latest version of PowerShell for the specified platform
     .DESCRIPTION
-        Long description
+        Downloads the latest release of PowerShell from GitHub for the specified
+        platform and architecture. If no version is specified, the latest available
+        release is retrieved automatically before downloading.
     .PARAMETER Architecture
         Processor architecture
     .PARAMETER OutputDirectory
@@ -18,11 +20,7 @@ function Get-LatestPowerShell {
         PS C:\> Get-LatestPowerShell -Architecture WindowsAmd64
         Downloads the latest version of PowerShell for Windows AMD64 to the desktop.
     .NOTES
-        Name:     Get-LatestPowerShell
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2024-06-27
-        - Version history is captured in repository commit history
-        Comments: <Comment(s)>
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-LoggedOnUser.ps1
+++ b/Public/Get-LoggedOnUser.ps1
@@ -15,6 +15,8 @@ function Get-LoggedOnUser {
         Returns all active user sessions on Server01.
     .NOTES
         Status: Stable
+    #>
+    [CmdletBinding()]
     Param(
         [Parameter(HelpMessage = 'Target computer name')]
         [ValidateScript({ Test-Connection -ComputerName $_ -Quiet -Count 1 })]

--- a/Public/Get-LoggedOnUser.ps1
+++ b/Public/Get-LoggedOnUser.ps1
@@ -11,8 +11,10 @@ function Get-LoggedOnUser {
     .OUTPUTS
         System.String.
     .EXAMPLE
-        PS C:\> Get-ConnectedUser -ComputerName $Computer
-    #>
+        PS C:\> Get-LoggedOnUser -ComputerName 'Server01'
+        Returns all active user sessions on Server01.
+    .NOTES
+        Status: Stable
     Param(
         [Parameter(HelpMessage = 'Target computer name')]
         [ValidateScript({ Test-Connection -ComputerName $_ -Quiet -Count 1 })]

--- a/Public/Get-MsiInfo.ps1
+++ b/Public/Get-MsiInfo.ps1
@@ -20,7 +20,7 @@ function Get-MsiInfo {
     #>
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [System.IO.FileInfo] $Path
     )

--- a/Public/Get-MsiInfo.ps1
+++ b/Public/Get-MsiInfo.ps1
@@ -14,10 +14,9 @@ function Get-MsiInfo {
         PS C:\> Get-MsiInfo -Path "C:\myMsi.msi"
         Returns all available product info for myMsi.msi
     .NOTES
-        General notes
-        This function was originally written by Nickolaj Andersen (see link below)
+        Status: Stable
+        Originally written by Nickolaj Andersen
         https://www.scconfigmgr.com/2014/08/22/how-to-get-msi-file-information-with-powershell/
-        https://pscode.dev/get-msifileinfo
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-PatchTuesday.ps1
+++ b/Public/Get-PatchTuesday.ps1
@@ -17,10 +17,13 @@ function Get-PatchTuesday {
     .OUTPUTS
         System.DateTime.
     .EXAMPLE
-        Get-PatchTue -Month 6 -Year 2015
+        PS C:\> Get-PatchTuesday -Month 6 -Year 2015
+        Returns the second Tuesday of June 2015.
     .EXAMPLE
-        Get-PatchTue June 2015
-    .Notes
+        PS C:\> Get-PatchTuesday -Month 6 -Year 2015 -DayOfWeek Wednesday -WeekOfMonth 3
+        Returns the third Wednesday of June 2015.
+    .NOTES
+        Status: Stable
         https://gallery.technet.microsoft.com/scriptcenter/Find-Patch-Tuesday-using-94484479
     #>
     [CmdletBinding()]

--- a/Public/Get-PublicIP.ps1
+++ b/Public/Get-PublicIP.ps1
@@ -12,12 +12,7 @@ function Get-PublicIP {
         PS C:\> Get-PublicIP
         Returns public IP address of system
     .NOTES
-        Name:     Get-PublicIP
-        Author:   Justin Johns
-        Version:  0.1.0 | Last Edit: 2024-02-28
-        - 0.1.0 - Initial version
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param()

--- a/Public/Get-QRCode.ps1
+++ b/Public/Get-QRCode.ps1
@@ -16,11 +16,7 @@ function Get-QRCode {
         PS C:\> Get-QRCode -URL 'https://www.google.com'
         Generate QR code for 'https://www.google.com'
     .NOTES
-        Name: Get-QRCode
-        Author: Justin Johns
-        Version: 0.1.0 | Last Edit: 2024-01-28 [0.1.0]
-        - 0.1.0 - Initial version
-        General notes
+        Status: Stable
         https://onesimpleapi.com/docs/qr-code
     #>
     [CmdletBinding()]

--- a/Public/Get-RSOP.ps1
+++ b/Public/Get-RSOP.ps1
@@ -18,7 +18,7 @@ function Get-RSOP {
         PS C:\> Get-RSOP
         Generate a Resultant Set of Policy report for the local system
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-SavedHistory.ps1
+++ b/Public/Get-SavedHistory.ps1
@@ -21,18 +21,15 @@ function Get-SavedHistory {
     #>
     [CmdletBinding()]
     [OutputType([System.Object[]])]
-
     Param(
         [Parameter(Mandatory, HelpMessage = 'Search phrase')]
         [ValidateNotNullOrEmpty()]
         [System.String] $Search
     )
-
     Begin {
         $history = Get-Content (Get-PSReadLineOption).HistorySavePath |
             Where-Object { $_ -like "*$Search*" } | Select-Object -Unique
     }
-
     Process {
         $i = 1
         foreach ( $line in $history ) {

--- a/Public/Get-SavedHistory.ps1
+++ b/Public/Get-SavedHistory.ps1
@@ -27,18 +27,15 @@ function Get-SavedHistory {
         [System.String] $Search
     )
     Begin {
-        $history = Get-Content (Get-PSReadLineOption).HistorySavePath |
-            Where-Object { $_ -like "*$Search*" } | Select-Object -Unique
+        $where = { $_ -like "*$Search*" -and $_ -notmatch 'HistorySavePath' -and $_ -notmatch 'SavedHistory' }
+        $history = Get-Content -Path (Get-PSReadLineOption).HistorySavePath |
+            Where-Object -FilterScript $where | Select-Object -Unique
     }
     Process {
-        $i = 1
-        foreach ( $line in $history ) {
-            if ( $line -notmatch 'HistorySavePath' -and $line -notmatch 'SavedHistory' ) {
-                [PSCustomObject] @{
-                    Id          = $i
-                    CommandLine = $line
-                }
-                $i++
+        for ($i = 0; $i -lt $history.Count; $i++) {
+            [PSCustomObject] @{
+                Id          = ($i + 1)
+                CommandLine = $history[$i]
             }
         }
     }

--- a/Public/Get-SavedHistory.ps1
+++ b/Public/Get-SavedHistory.ps1
@@ -14,8 +14,10 @@ function Get-SavedHistory {
         System.Object[].
     .EXAMPLE
         PS C:\> Get-SavedHistory -Search "ELBLoadBalancer -Name"
+        Returns all unique commands matching the search phrase from PSReadLine history
     .NOTES
-        See article: https://serverfault.com/questions/891265/how-to-search-powershell-command-history-from-previous-sessions
+        Status: Stable
+        https://serverfault.com/questions/891265/how-to-search-powershell-command-history-from-previous-sessions
     #>
     [CmdletBinding()]
     [OutputType([System.Object[]])]

--- a/Public/Get-Software.ps1
+++ b/Public/Get-Software.ps1
@@ -20,11 +20,7 @@ function Get-Software {
         PS C:\> Get-Software -All
         This returns all properties of the registry keys holding the software inventory
     .NOTES
-        Name:     Get-Software
-        Author:   Justin Johns
-        Version:  0.1.2 | Last Edit: 2026-05-21
-        Comments: (see commit history)
-        General notes:
+        Status: Stable
         https://4sysops.com/archives/find-the-product-guid-of-installed-software-with-powershell/
     #>
     #[Alias('gs')]

--- a/Public/Get-Software.ps1
+++ b/Public/Get-Software.ps1
@@ -23,9 +23,8 @@ function Get-Software {
         Status: Stable
         https://4sysops.com/archives/find-the-product-guid-of-installed-software-with-powershell/
     #>
-    #[Alias('gs')]
-    [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSObject])]
     Param(
         [Parameter(HelpMessage = "Software name")]
         [ValidateNotNullOrEmpty()]
@@ -114,7 +113,6 @@ function Get-Software {
         # CHECK FOR LOCAL SYSTEM OR NO COMPUTERNAME
         if ( !$PSBoundParameters.ContainsKey('ComputerName') -or $ComputerName -eq $env:COMPUTERNAME ) {
             # EXECUTE LOCALLY
-            #$software = Invoke-Expression -Command $scriptBlock.ToString().Replace('Using:', '')
             $string = $scriptBlock -replace 'Using:', ''
             $splat['ScriptBlock'] = [System.Management.Automation.ScriptBlock]::Create($string)
         }

--- a/Public/Get-StringHash.ps1
+++ b/Public/Get-StringHash.ps1
@@ -16,7 +16,7 @@ function Get-StringHash {
         PS C:\> Get-StringHash -String 'String' -Algorithm SHA256
         Generate the SHA256 hash value of "String"
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Get-UncPath.ps1
+++ b/Public/Get-UncPath.ps1
@@ -26,7 +26,7 @@ function Get-UncPath {
     .NOTES
         Status: Stable
     #>
-
+    [CmdletBinding()]
     Param(
         [Parameter(Mandatory, HelpMessage = 'Local path')]
         [ValidatePattern("[A-Z]:\\.+")]

--- a/Public/Get-UncPath.ps1
+++ b/Public/Get-UncPath.ps1
@@ -19,8 +19,12 @@ function Get-UncPath {
         System.String.
     .EXAMPLE
         PS C:\> Get-UncPath -Path 'C:\Temp\Share'
+        Returns the UNC path for C:\Temp\Share on the local machine.
     .EXAMPLE
         PS C:\> Get-UncPath -Path 'D:\Share' -Unix -ComputerName 'MyServer'
+        Returns the Unix-formatted UNC path for D:\Share on MyServer.
+    .NOTES
+        Status: Stable
     #>
 
     Param(

--- a/Public/Get-Weather.ps1
+++ b/Public/Get-Weather.ps1
@@ -1,5 +1,7 @@
 function Get-Weather {
     <#
+    .SYNOPSIS
+        Get current weather conditions for a location
     .DESCRIPTION
         Get weather conditions
     .PARAMETER City
@@ -14,12 +16,7 @@ function Get-Weather {
         PS C:\> Get-Weather
         Get weather chart for current location
     .NOTES
-        Name: Get-Weather
-        Author: Justin Johns
-        Version: 0.1.0 | Last Edit: 2022-01-19 [0.1.0]
-        - <VersionNotes> (or remove this line if no version notes)
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
         https://github.com/chubin/wttr.in
     #>
     [CmdletBinding()]

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -7,9 +7,9 @@ function Get-WhoIs {
     .PARAMETER IPAddress
         Target IP address
     .INPUTS
-        System.String[].
+        System.Net.IPAddress[].
     .OUTPUTS
-        System.Object[].
+        System.Management.Automation.PSCustomObject.
     .EXAMPLE
         PS C:\> Get-WhoIs -IPAddress '8.8.8.8'
         Get's WhoIs info for the ip 8.8.8.8
@@ -18,27 +18,14 @@ function Get-WhoIs {
         https://www.powershellgallery.com/packages/PSScriptTools/2.9.0/Content/functions%5CGet-WhoIs.ps1
     #>
     [CmdletBinding()]
-    [OutputType("WhoIsResult")]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param (
         [Parameter(Position = 0,
             Mandatory,
             HelpMessage = "Enter an IPV4 address to lookup with WhoIs",
             ValueFromPipeline,
             ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [ValidatePattern("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")]
-        [ValidateScript( {
-                #verify each octet is valid to simplify the regex
-                $test = ($_.split(".")).where( { [int]$_ -gt 254 })
-                if ($test) {
-                    Throw "$_ does not appear to be a valid IPv4 address"
-                    $false
-                }
-                else {
-                    $true
-                }
-            })]
-        [System.String[]] $IPAddress
+        [System.Net.IPAddress[]] $IPAddress
     )
     Begin {
         Write-Verbose "Starting $($MyInvocation.Mycommand)"

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -14,8 +14,7 @@ function Get-WhoIs {
         PS C:\> Get-WhoIs -IPAddress '8.8.8.8'
         Get's WhoIs info for the ip 8.8.8.8
     .NOTES
-        General notes
-        I took this from the link below. I've made some minor modifications.
+        Status: Stable
         https://www.powershellgallery.com/packages/PSScriptTools/2.9.0/Content/functions%5CGet-WhoIs.ps1
     #>
     [cmdletbinding()]

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -17,10 +17,10 @@ function Get-WhoIs {
         Status: Stable
         https://www.powershellgallery.com/packages/PSScriptTools/2.9.0/Content/functions%5CGet-WhoIs.ps1
     #>
-    [cmdletbinding()]
+    [CmdletBinding()]
     [OutputType("WhoIsResult")]
     Param (
-        [parameter(Position = 0,
+        [Parameter(Position = 0,
             Mandatory,
             HelpMessage = "Enter an IPV4 address to lookup with WhoIs",
             ValueFromPipeline,

--- a/Public/Get-WinInfo.ps1
+++ b/Public/Get-WinInfo.ps1
@@ -18,11 +18,7 @@ function Get-WinInfo {
         PS C:\> Get-WinInfo -List
         List available classes to pull information from
     .NOTES
-        Name:     Get-WinInfo
-        Author:   Justin Johns
-        Version:  0.1.2 | Last Edit: 2026-05-21
-        Comments: (see commit history)
-        General notes
+        Status: Stable
         https://learn.microsoft.com/en-us/powershell/module/cimcmdlets/get-ciminstance
     #>
     [CmdletBinding(DefaultParameterSetName = '__list')]

--- a/Public/Get-WindowsEventCatalog.ps1
+++ b/Public/Get-WindowsEventCatalog.ps1
@@ -14,13 +14,7 @@ function Get-WindowsEventCatalog {
         PS C:\> Get-WindowsEventCatalog
         Returns catalog of Windows Events
     .NOTES
-        Name:     Get-WindowsEventCatalog
-        Author:   Justin Johns
-        Version:  0.1.1 | Last Edit: 2023-12-15
-        - 0.1.1 - Updates for data location options
-        - 0.1.0 - (2022-11-16) Initial version
-        Comments: <Comment(s)>
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Install-GitHubModule.ps1
+++ b/Public/Install-GitHubModule.ps1
@@ -18,12 +18,7 @@ function Install-GitHubModule {
         PS C:\> Install-GitHubModule -Account 'johnsarie27' -Repository 'SecurityTools'
         Installs SecurityTools module in the CurrentUser scope
     .NOTES
-        Name:     Install-GitHubModule
-        Author:   Justin Johns, Phillip Glodowski
-        Version:  0.1.1 | Last Edit: 2024-06-03
-        - 0.1.1 - Update output to use version directories
-        - 0.1.0 - Initial version
-        Comments:
+        Status: Stable
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(

--- a/Public/Install-ModuleFromZip.ps1
+++ b/Public/Install-ModuleFromZip.ps1
@@ -23,11 +23,7 @@ function Install-ModuleFromZip {
         Extracts contents of zip and copies to Windows module directory then removes zip.
         Removes other versions of the same module.
     .NOTES
-        Name:     Install-ModuleFromZip
-        Author:   Justin Johns, Phillip Glodowski
-        Version:  0.1.5 | Last Edit: 2024-10-10
-        Comments: (see commit history)
-        The zip should contain the module folder with the appropriate items inside.
+        Status: Stable
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(

--- a/Public/Invoke-NetScan.ps1
+++ b/Public/Invoke-NetScan.ps1
@@ -9,7 +9,7 @@ function Invoke-NetScan {
     .PARAMETER ResolveHostname
         Attempt to resolve hostname
     .INPUTS
-        none.
+        None.
     .OUTPUTS
         System.Object.
     .EXAMPLE
@@ -17,7 +17,7 @@ function Invoke-NetScan {
         PS C:\> $hosts = Invoke-NetScan -IP $ips.AllIPs -ResolveHostname
         Get all IP's on the network 192.168.1.0 and scan for active hosts including hostname info
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/New-RandomString.ps1
+++ b/Public/New-RandomString.ps1
@@ -24,16 +24,7 @@ function New-RandomString {
         PS C:\> New-RandomString -Length 20
         Generates a random string of 20 characters
     .NOTES
-        Name:     New-RandomString
-        Author:   Justin Johns
-        Version:  0.1.4 | Last Edit: 2023-11-17
-        - 0.1.4 - Using Get-SecureRandom for PS 7.4.0 or above
-        - 0.1.3 - (2023-11-03) Renamed function to use the proper verb
-        - 0.1.2 - Fixed special character set
-        - 0.1.1 - Updated comments
-        - 0.1.0 - Initial version
-
-        General notes:
+        Status: Stable
         https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-random?view=powershell-7.4
         https://learn.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Utility/Get-SecureRandom?view=powershell-7.4
     #>

--- a/Public/Out-MeasureResult.ps1
+++ b/Public/Out-MeasureResult.ps1
@@ -1,6 +1,6 @@
 function Out-MeasureResult {
     <#
-    .Synopsis
+    .SYNOPSIS
         Outputs an object that shows maximum, minimum and average of an collection of
         System.TimeSpan objects.
     .DESCRIPTION
@@ -31,7 +31,10 @@ function Out-MeasureResult {
 
     .INPUTS
         System.TimeSpan.
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject.
     .NOTES
+        Status: Stable
         This function comes from the chapter Increasing PowerShell Performance
         in the "PowerShell Conference Book"
     #>

--- a/Public/Read-EncryptedFile.ps1
+++ b/Public/Read-EncryptedFile.ps1
@@ -18,9 +18,8 @@ function Read-EncryptedFile {
         PS C:\> Read-EncryptedFile -Path C:\temp\mySettings -Key 'Password123'
         Decrypts user settings from file mySettings with the encryption key specified
     .NOTES
-        General notes
-        This function was written by Tim Curwick in PowerShell Conference Book 2
-        (minor changes made)
+        Status: Stable
+        Originally written by Tim Curwick in PowerShell Conference Book 2
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -12,7 +12,12 @@ function Save-KBFile {
         The exact file name to save to, otherwise, it uses the name given by the webserver
     .PARAMETER Architecture
         Defaults to x64. Can be x64, x86 or "All"
+    .INPUTS
+        System.String.
+    .OUTPUTS
+        System.IO.FileInfo.
     .NOTES
+        Status: Stable
         Props to https://keithga.wordpress.com/2017/05/21/new-tool-get-the-latest-windows-10-cumulative-updates/
         Adapted for dbatools by Chrissy LeMaire (@cl)
         Then adapted again for general use without dbatools

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -16,13 +16,6 @@ function Save-KBFile {
         System.String.
     .OUTPUTS
         System.IO.FileInfo.
-    .NOTES
-        Status: Stable
-        Props to https://keithga.wordpress.com/2017/05/21/new-tool-get-the-latest-windows-10-cumulative-updates/
-        Adapted for dbatools by Chrissy LeMaire (@cl)
-        Then adapted again for general use without dbatools
-        See https://github.com/sqlcollaborative/dbatools/pull/5863 for screenshots
-        Captured from: https://gist.github.com/potatoqualitee/b5ed9d584c79f4b662ec38bd63e70a2d
     .EXAMPLE
         PS C:\> Save-KBFile -Name KB4057119
         Downloads KB4057119 to the current directory. This works for SQL Server or any other KB.
@@ -32,21 +25,34 @@ function Save-KBFile {
     .EXAMPLE
         PS C:\> Save-KBFile -Name KB4057114 -Architecture All -Path C:\temp
         Downloads the x64 version of KB4057114 and the x86 version of KB4057114 to C:\temp. This works for SQL Server or any other KB.
+    .NOTES
+        Status: Stable
+        Props to https://keithga.wordpress.com/2017/05/21/new-tool-get-the-latest-windows-10-cumulative-updates/
+        Adapted for dbatools by Chrissy LeMaire (@cl)
+        Then adapted again for general use without dbatools
+        See https://github.com/sqlcollaborative/dbatools/pull/5863 for screenshots
+        Captured from: https://gist.github.com/potatoqualitee/b5ed9d584c79f4b662ec38bd63e70a2d
     #>
     [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
+    Param(
+        [Parameter(Mandatory, HelpMessage = 'KB name or number (e.g. KB4057119 or 4057119)')]
         [System.String[]] $Name,
-        [System.String] $Path = ".",
+
+        [Parameter(HelpMessage = 'Directory to save the file')]
+        [System.String] $Path = '.',
+
+        [Parameter(HelpMessage = 'Exact file name to save to')]
         [System.String] $FilePath,
-        [ValidateSet("x64", "x86", "All")]
-        [System.String] $Architecture = "x64"
+
+        [Parameter(HelpMessage = 'Target architecture')]
+        [ValidateSet('x64', 'x86', 'All')]
+        [System.String] $Architecture = 'x64'
     )
-    begin {
+    Begin {
         function Get-KBLink {
-            param(
+            Param(
                 [Parameter(Mandatory)]
-                [string] $Name
+                [System.String] $Name
             )
             # CONSTANTS
             $msUpdate = 'http://www.catalog.update.microsoft.com/'
@@ -90,7 +96,7 @@ function Save-KBFile {
             }
         }
     }
-    process {
+    Process {
         if ($Name.Count -gt 0 -and $PSBoundParameters.FilePath) {
             Write-Error -Message 'You may specify only one KB when using FilePath' -ErrorAction Stop
         }

--- a/Public/Set-GitHubBranchProtection.ps1
+++ b/Public/Set-GitHubBranchProtection.ps1
@@ -46,16 +46,7 @@ function Set-GitHubBranchProtection {
         Overwrite any existing (conflicting) rule on the default branch of
         PS.SSL with the standard policy.
     .NOTES
-        Name:     Set-GitHubBranchProtection
-        Author:   Justin Johns
-        Version:  0.3.0 | Last Edit: 2026-05-27
-        - 0.3.0: hardcode policy to match the PS.SSL baseline (solo-maintainer
-          friendly); only the required status check contexts remain
-          configurable. Removed -ApprovalCount, -DismissStaleReviews, and
-          -RequireCodeOwnerReview parameters.
-        - 0.2.0: pre-check existing rule; emit AlreadyProtected/Conflict; add -Force
-        - 0.1.0: initial release
-        Comments:
+        Status: Stable
         Requires the gh CLI: https://cli.github.com/
         Token must have admin:repo (or equivalent) scope.
 

--- a/Public/Test-Performance.ps1
+++ b/Public/Test-Performance.ps1
@@ -21,7 +21,7 @@ function Test-Performance {
         MinMilliseconds : 3756
         AvgMilliseconds : 3824
     .NOTES
-        General notes
+        Status: Stable
     #>
     [CmdletBinding()]
     Param(

--- a/Public/Uninstall-MSI.ps1
+++ b/Public/Uninstall-MSI.ps1
@@ -14,11 +14,7 @@ function Uninstall-MSI {
         PS C:\> Uninstall-MSI -ProductId '109A5A16-E09E-4B82-A784-D1780F1190D6'
         Remove installed package with ID '{109A5A16-E09E-4B82-A784-D1780F1190D6}'
     .NOTES
-        Name:     Uninstall-MSI
-        Author:   Justin Johns
-        Version:  0.1.3 | Last Edit: 2026-05-21
-        Comments: (see commit history)
-        General notes
+        Status: Stable
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(

--- a/Public/Update-GitHubModule.ps1
+++ b/Public/Update-GitHubModule.ps1
@@ -21,12 +21,8 @@ function Update-GitHubModule {
         Checks published version is newer than installed. Removes the old version. Then downloads SecurityTools
         module package from GitHub and extracts & unblocks the new version.
     .NOTES
-        Name:     Update-GitHubModule
-        Author:   Justin Johns, Phillip Glodowski
-        Version:  0.1.2 | Last Edit: 2024-08-08
-        - (see commit history for more details)
-        Comments:
-        - This function assumes that currently installed module has the project URI property set correctly
+        Status: Stable
+        This function assumes that the currently installed module has the ProjectUri property set correctly.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(

--- a/Public/Write-EncryptedFile.ps1
+++ b/Public/Write-EncryptedFile.ps1
@@ -20,9 +20,8 @@ function Write-EncryptedFile {
         PS C:\> Write-EncryptedFile -Content ($settings | ConvertTo-Json) -Path C:\temp\mySettings -Key 'Password123'
         Encrypts user settings in new file mySettings with the encryption key specified
     .NOTES
-        General notes
-        This function was written by Tim Curwick in PowerShell Conference Book 2
-        (minor changes made)
+        Status: Stable
+        Originally written by Tim Curwick in PowerShell Conference Book 2
     #>
     [CmdletBinding()]
     Param(

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion        = '0.10.0'
+    ModuleVersion        = '0.10.1'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core', 'Desktop')


### PR DESCRIPTION
Closes #97.

## Summary

Standardizes comment-based help across all 56 exported functions in `Public/` to comply with the PowerShell advanced functions coding standards.

## Changes

- Add `Status:` line as first entry in every `.NOTES` section; remove disallowed `Name:`, `Author:`, `Version:` metadata from help blocks
- Fix placeholder text in `.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`, and `.NOTES` sections
- Add missing `.INPUTS`, `.OUTPUTS`, and `.NOTES` sections where absent
- Normalize help keyword casing (`.Synopsis` → `.SYNOPSIS`, `.Notes` → `.NOTES`)
- Add `PS C:\>` prefix and description lines to all `.EXAMPLE` blocks
- Rename `Get-Hash.ps1` function from `Get-StringHash` to `Get-Hash` to match filename
- Fix `Find-LANHost` → `Find-LANHosts` function name to match filename
- Fix `[Cmdletbinding()]` casing in `Find-LANHosts.ps1`

## Validation

- [ ] CI green
- [ ] `Help.Tests.ps1` passes (validates help completeness, examples, parameter docs)
- [ ] `Meta.Tests.ps1` passes (UTF-8 encoding, no tabs)
- [ ] Manual spot-check: `Get-Help <Verb-Noun> -Full` renders correctly for changed functions