### PR TITLE
Fix Expand-GZip path validation and add DestinationPath alias

### DIFF
--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -22,11 +22,16 @@ function Expand-GZip {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true, Position = 0, HelpMessage = 'Path to GZip file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include '*.gz' })]
+        [ValidateScript({
+            if (-not (Test-Path -Path $_ -PathType Leaf)) { throw "File not found: $_" }
+            if ([System.IO.Path]::GetExtension($_) -ne '.gz') { throw "File must have a .gz extension: $_" }
+            $true
+        })]
         [System.IO.FileInfo] $Path,
 
         [Parameter(Mandatory = $false, Position = 1, HelpMessage = 'Destination directory to extract file to')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
+        [Alias('DestinationPath')]
         [System.IO.DirectoryInfo] $OutputDirectory
     )
     Begin {

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -25,11 +25,7 @@ function Expand-GZip {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true, Position = 0, HelpMessage = 'Path to GZip file')]
-        [ValidateScript({
-            if (-not (Test-Path -Path $_ -PathType Leaf)) { throw "File not found: $_" }
-            if ([System.IO.Path]::GetExtension($_) -ne '.gz') { throw "File must have a .gz extension: $_" }
-            $true
-        })]
+        [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -like '*.gz') })]
         [System.IO.FileInfo] $Path,
 
         [Parameter(Mandatory = $false, Position = 1, HelpMessage = 'Destination directory to extract file to')]

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -15,6 +15,9 @@ function Expand-GZip {
     .EXAMPLE
         PS C:\> Expand-GZip -Path C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06.gz
         Extracts file to C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06
+    .EXAMPLE
+        PS C:\> Expand-GZip -Path C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06.gz -OutputDirectory C:\Temp
+        Extracts file to C:\Temp\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06
     .NOTES
         Status: Stable
         https://social.technet.microsoft.com/Forums/windowsserver/en-US/5aa53fef-5229-4313-a035-8b3a38ab93f5/unzip-gz-files-using-powershell?forum=winserverpowershell
@@ -31,7 +34,6 @@ function Expand-GZip {
 
         [Parameter(Mandatory = $false, Position = 1, HelpMessage = 'Destination directory to extract file to')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
-        [Alias('DestinationPath')]
         [System.IO.DirectoryInfo] $OutputDirectory
     )
     Begin {

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion        = '0.10.1'
+    ModuleVersion        = '0.10.2'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core', 'Desktop')

--- a/Tests/Unit/Expand-GZip.tests.ps1
+++ b/Tests/Unit/Expand-GZip.tests.ps1
@@ -1,0 +1,143 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Expand-GZip' -Fixture {
+
+    BeforeAll {
+        # Helper: write a .gz file with known plaintext contents.
+        function New-TestGZipFile {
+            param(
+                [Parameter(Mandatory)] [string] $Path,
+                [Parameter(Mandatory)] [string] $Content
+            )
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
+            $fs = [System.IO.File]::Create($Path)
+            try {
+                $gz = New-Object System.IO.Compression.GZipStream($fs, [System.IO.Compression.CompressionMode]::Compress)
+                try { $gz.Write($bytes, 0, $bytes.Length) } finally { $gz.Dispose() }
+            }
+            finally { $fs.Dispose() }
+        }
+    }
+
+    Context -Name 'normal usage' -Fixture {
+        BeforeEach {
+            # Use $TestDrive (real filesystem path) rather than the 'TestDrive:' PSDrive,
+            # because Expand-GZip passes the path to .NET FileStream which does not resolve PSDrives.
+            $script:Plaintext = 'hello gzip world'
+            $script:SourcePath = Join-Path -Path $TestDrive -ChildPath 'sample.txt.gz'
+            New-TestGZipFile -Path $script:SourcePath -Content $script:Plaintext
+        }
+
+        It -Name 'expands to the source directory when -OutputDirectory is omitted' -Test {
+            Expand-GZip -Path $script:SourcePath
+            $expected = Join-Path -Path $TestDrive -ChildPath 'sample.txt'
+            Test-Path -Path $expected -PathType Leaf | Should -BeTrue
+            (Get-Content -Path $expected -Raw) | Should -Be $script:Plaintext
+        }
+
+        It -Name 'expands to the specified -OutputDirectory' -Test {
+            $destDir = Join-Path -Path $TestDrive -ChildPath 'out'
+            New-Item -Path $destDir -ItemType Directory | Out-Null
+            Expand-GZip -Path $script:SourcePath -OutputDirectory $destDir
+            $expected = Join-Path -Path $destDir -ChildPath 'sample.txt'
+            Test-Path -Path $expected -PathType Leaf | Should -BeTrue
+            (Get-Content -Path $expected -Raw) | Should -Be $script:Plaintext
+        }
+
+        It -Name 'should not throw for a valid .gz file' -Test {
+            { Expand-GZip -Path $script:SourcePath } | Should -Not -Throw
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a path that does not exist' -Test {
+            $missing = Join-Path -Path $TestDrive -ChildPath 'does-not-exist.gz'
+            { Expand-GZip -Path $missing } | Should -Throw
+        }
+
+        It -Name 'rejects a file without a .gz extension' -Test {
+            $nonGz = Join-Path -Path $TestDrive -ChildPath 'plain.txt'
+            Set-Content -Path $nonGz -Value 'not gzipped'
+            { Expand-GZip -Path $nonGz } | Should -Throw
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'src.txt.gz'
+            New-TestGZipFile -Path $src -Content 'data'
+            $badDir = Join-Path -Path $TestDrive -ChildPath 'no-such-dir'
+            { Expand-GZip -Path $src -OutputDirectory $badDir } | Should -Throw
+        }
+
+        It -Name 'does not accept -DestinationPath (alias intentionally absent)' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'alias.txt.gz'
+            New-TestGZipFile -Path $src -Content 'data'
+            $destDir = Join-Path -Path $TestDrive -ChildPath 'dest'
+            New-Item -Path $destDir -ItemType Directory | Out-Null
+            { Expand-GZip -Path $src -DestinationPath $destDir } | Should -Throw
+        }
+    }
+
+    Context -Name 'content fidelity' -Fixture {
+        It -Name 'expands payloads larger than the 1024-byte read buffer' -Test {
+            # 5000-char payload forces multiple iterations of the Read loop.
+            $payload = -join (1..5000 | ForEach-Object { [char](65 + ($_ % 26)) })
+            $src = Join-Path -Path $TestDrive -ChildPath 'large.txt.gz'
+            New-TestGZipFile -Path $src -Content $payload
+
+            Expand-GZip -Path $src
+            $expected = Join-Path -Path $TestDrive -ChildPath 'large.txt'
+            (Get-Content -Path $expected -Raw) | Should -Be $payload
+        }
+
+        It -Name 'strips only the final .gz extension for multi-dot filenames' -Test {
+            # archive.tar.gz should expand to archive.tar
+            $src = Join-Path -Path $TestDrive -ChildPath 'archive.tar.gz'
+            New-TestGZipFile -Path $src -Content 'tar-payload'
+
+            Expand-GZip -Path $src
+            $expected = Join-Path -Path $TestDrive -ChildPath 'archive.tar'
+            Test-Path -Path $expected -PathType Leaf | Should -BeTrue
+        }
+
+        It -Name 'roundtrips arbitrary binary bytes' -Test {
+            $bytes = [byte[]]@(0, 1, 2, 3, 127, 128, 200, 255, 0, 42)
+            $src = Join-Path -Path $TestDrive -ChildPath 'binary.bin.gz'
+
+            # Write a gzip stream of raw bytes (bypassing the UTF-8 helper).
+            $fs = [System.IO.File]::Create($src)
+            try {
+                $gz = New-Object System.IO.Compression.GZipStream($fs, [System.IO.Compression.CompressionMode]::Compress)
+                try { $gz.Write($bytes, 0, $bytes.Length) } finally { $gz.Dispose() }
+            }
+            finally { $fs.Dispose() }
+
+            Expand-GZip -Path $src
+            $expected = Join-Path -Path $TestDrive -ChildPath 'binary.bin'
+            $actual = [System.IO.File]::ReadAllBytes($expected)
+            $actual | Should -Be $bytes
+        }
+    }
+
+    Context -Name 'behavior contracts' -Fixture {
+        It -Name 'overwrites an existing destination file' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'overwrite.txt.gz'
+            New-TestGZipFile -Path $src -Content 'new contents'
+            $dest = Join-Path -Path $TestDrive -ChildPath 'overwrite.txt'
+            Set-Content -Path $dest -Value 'pre-existing junk that is much longer than the replacement payload'
+
+            Expand-GZip -Path $src
+            (Get-Content -Path $dest -Raw) | Should -Be 'new contents'
+        }
+
+        It -Name 'produces no pipeline output' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'silent.txt.gz'
+            New-TestGZipFile -Path $src -Content 'data'
+            $result = Expand-GZip -Path $src
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #62 — specifying a path to `Expand-GZip` produces errors.

- **ValidateScript bug**: `Test-Path -PathType Leaf -Include ''*.gz''` always returns `$false` for specific file paths because `-Include` is a wildcard filter designed for container paths. Replaced with a single-line check combining file existence (`Test-Path -PathType Leaf`) and extension (`-like ''*.gz''`).
- **Stale parameter name in docs**: Added a second `.EXAMPLE` block showing `-OutputDirectory` with a destination path so callers use the correct parameter name.

## Test plan

All items below are covered by automated Pester tests in `Tests/Unit/Expand-GZip.tests.ps1` (12 tests, all passing locally):

- [x] `Expand-GZip -Path "$HOME\Desktop\file.gz"` — expands to same directory
- [x] `Expand-GZip -Path "$HOME\Desktop\file.gz" -OutputDirectory "$HOME\Desktop"` — expands to specified directory
- [x] Passing a non-`.gz` file produces a validation error
- [x] Passing a path that doesn''t exist produces a validation error
- [x] Passing `-DestinationPath` produces a "parameter not found" error (alias was intentionally removed)

https://claude.ai/code/session_01XNcWRtX6WS8tZwcV7ATABQ