### PR TITLE
feat(Public): add -Force / SupportsShouldProcess to Expand-GZip (closes #101)

### DIFF
--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -8,6 +8,8 @@ function Expand-GZip {
         Path to GZip file
     .PARAMETER OutputDirectory
         Destination directory to extract file to
+    .PARAMETER Force
+        Overwrite the destination file if it already exists.
     .INPUTS
         None.
     .OUTPUTS
@@ -18,11 +20,14 @@ function Expand-GZip {
     .EXAMPLE
         PS C:\> Expand-GZip -Path C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06.gz -OutputDirectory C:\Temp
         Extracts file to C:\Temp\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06
+    .EXAMPLE
+        PS C:\> Expand-GZip -Path C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06.gz -Force
+        Extracts file, overwriting C:\E3IU1BL3AWXV9B.2023-10-30-21.b3052b06 if it already exists
     .NOTES
         Status: Stable
         https://social.technet.microsoft.com/Forums/windowsserver/en-US/5aa53fef-5229-4313-a035-8b3a38ab93f5/unzip-gz-files-using-powershell?forum=winserverpowershell
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     Param(
         [Parameter(Mandatory = $true, Position = 0, HelpMessage = 'Path to GZip file')]
         [ValidateScript({ (Test-Path -Path $_ -PathType Leaf) -and ($_ -like '*.gz') })]
@@ -30,7 +35,10 @@ function Expand-GZip {
 
         [Parameter(Mandatory = $false, Position = 1, HelpMessage = 'Destination directory to extract file to')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
-        [System.IO.DirectoryInfo] $OutputDirectory
+        [System.IO.DirectoryInfo] $OutputDirectory,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Overwrite the destination file if it already exists')]
+        [Switch] $Force
     )
     Begin {
         Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
@@ -39,17 +47,30 @@ function Expand-GZip {
         # CHECK FOR DESTINATION PATH
         if ($PSBoundParameters.ContainsKey('OutputDirectory')) {
             # SET DESTINATION TO FULL, DECOMPRESSED FILE PATH
-            #$destFullPath = Join-Path -Path $OutputDirectory -ChildPath ([System.IO.Path]::GetFileNameWithoutExtension($Path))
             $destFullPath = Join-Path -Path $OutputDirectory -ChildPath (Split-Path -Path $Path -LeafBase)
         }
         else {
             # IF NO DESTINATION PATH IS PROVIDED, USE THE SAME PATH AS THE GZIP FILE BUT WITHOUT THE .GZ EXTENSION
-            #$destFullPath = $Path -replace '\.gz$', ''
             $destFullPath = Join-Path -Path (Split-Path -Path $Path) -ChildPath (Split-Path -Path $Path -LeafBase)
+        }
+
+        # REFUSE TO OVERWRITE AN EXISTING DESTINATION UNLESS -Force WAS PASSED
+        if ((Test-Path -Path $destFullPath -PathType Leaf) -and -not $Force) {
+            $errParams = @{
+                Message     = "Destination file [$destFullPath] already exists. Use -Force to overwrite."
+                Category    = 'ResourceExists'
+                ErrorAction = 'Stop'
+            }
+            Write-Error @errParams
         }
 
         # OUTPUT VERBOSE MESSAGE
         Write-Verbose -Message ('Expanding GZip file [{0}] to [{1}]' -f $Path, $destFullPath)
+
+        # HONOR -WhatIf / -Confirm
+        if (-not $PSCmdlet.ShouldProcess($destFullPath, 'Expand-GZip')) {
+            return
+        }
 
         # CREATE .NET OBJECTS
         $ip = New-Object System.IO.FileStream $Path, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
@@ -64,9 +85,9 @@ function Expand-GZip {
         }
     }
     End {
-        # CLOSE STREAMS
-        $gzipStream.Close()
-        $op.Close()
-        $ip.Close()
+        # CLOSE STREAMS (guard against -WhatIf paths where streams were never opened)
+        if ($gzipStream) { $gzipStream.Close() }
+        if ($op) { $op.Close() }
+        if ($ip) { $ip.Close() }
     }
 }

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion        = '0.10.2'
+    ModuleVersion        = '0.10.3'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core', 'Desktop')

--- a/Tests/Unit/Expand-GZip.tests.ps1
+++ b/Tests/Unit/Expand-GZip.tests.ps1
@@ -29,7 +29,10 @@ Describe -Name 'Expand-GZip' -Fixture {
             # because Expand-GZip passes the path to .NET FileStream which does not resolve PSDrives.
             $script:Plaintext = 'hello gzip world'
             $script:SourcePath = Join-Path -Path $TestDrive -ChildPath 'sample.txt.gz'
+            $script:DestPath = Join-Path -Path $TestDrive -ChildPath 'sample.txt'
             New-TestGZipFile -Path $script:SourcePath -Content $script:Plaintext
+            # Clean any leftover destination from a previous It in this Context.
+            if (Test-Path -Path $script:DestPath) { Remove-Item -Path $script:DestPath -Force }
         }
 
         It -Name 'expands to the source directory when -OutputDirectory is omitted' -Test {
@@ -123,14 +126,33 @@ Describe -Name 'Expand-GZip' -Fixture {
     }
 
     Context -Name 'behavior contracts' -Fixture {
-        It -Name 'overwrites an existing destination file' -Test {
+        It -Name 'refuses to overwrite an existing destination file without -Force' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'no-overwrite.txt.gz'
+            New-TestGZipFile -Path $src -Content 'new contents'
+            $dest = Join-Path -Path $TestDrive -ChildPath 'no-overwrite.txt'
+            Set-Content -Path $dest -Value 'pre-existing'
+
+            { Expand-GZip -Path $src } | Should -Throw -ExpectedMessage '*already exists*'
+            (Get-Content -Path $dest -Raw) | Should -Be "pre-existing$([Environment]::NewLine)"
+        }
+
+        It -Name 'overwrites an existing destination file when -Force is passed' -Test {
             $src = Join-Path -Path $TestDrive -ChildPath 'overwrite.txt.gz'
             New-TestGZipFile -Path $src -Content 'new contents'
             $dest = Join-Path -Path $TestDrive -ChildPath 'overwrite.txt'
             Set-Content -Path $dest -Value 'pre-existing junk that is much longer than the replacement payload'
 
-            Expand-GZip -Path $src
+            Expand-GZip -Path $src -Force
             (Get-Content -Path $dest -Raw) | Should -Be 'new contents'
+        }
+
+        It -Name '-WhatIf produces no destination file' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'whatif.txt.gz'
+            New-TestGZipFile -Path $src -Content 'data'
+            $dest = Join-Path -Path $TestDrive -ChildPath 'whatif.txt'
+
+            Expand-GZip -Path $src -WhatIf
+            Test-Path -Path $dest | Should -BeFalse
         }
 
         It -Name 'produces no pipeline output' -Test {


### PR DESCRIPTION
## Summary

Adds a `-Force` switch and `[CmdletBinding(SupportsShouldProcess)]` to `Expand-GZip` so the safe default is to refuse overwriting an existing destination file. Matches the convention of `Expand-Archive`, `Copy-Item`, and `Out-File`.

Closes #101.

## Changes

- Declare `[CmdletBinding(SupportsShouldProcess)]` on `Expand-GZip`.
- Add `[Switch] $Force` parameter with comment-based help.
- Refuse to overwrite an existing destination file unless `-Force` is passed (terminating error via `Write-Error -ErrorAction Stop`).
- Gate the write on `$PSCmdlet.ShouldProcess($destFullPath, ''Expand-GZip'')` so `-WhatIf` reports the intended write without performing it.
- Add `.EXAMPLE` block demonstrating `-Force`.
- Update Pester tests in `Tests/Unit/Expand-GZip.tests.ps1`:
  - Flip existing "overwrites an existing destination file" test to require `-Force`.
  - Add test: without `-Force` against an existing destination, throws.
  - Add test: `-WhatIf` produces no file.
- Bump module version (patch bump 0.10.2 -> 0.10.3).

## Breaking change

This changes the default behavior for callers who relied on silent overwrite. Callers must now pass `-Force` to retain the previous behavior. Noted in commit body as `BREAKING CHANGE:`.

## Validation

- [x] CI green (Analyze + Test)
- [x] All 14 Pester tests in `Expand-GZip.tests.ps1` pass
- [x] `Expand-GZip` without `-Force` against existing destination throws as expected
- [x] `Expand-GZip -WhatIf` reports destination, writes nothing
- [x] `Expand-GZip -Force` overwrites as before