### PR TITLE
chore(Public): align module with PowerShell coding standards

### DIFF
--- a/Public/Compare-List.ps1
+++ b/Public/Compare-List.ps1
@@ -47,6 +47,8 @@ function Compare-List {
         [System.Object[]] $ListB
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # CREATE RESULTS COLLECTION
         $results = [System.Collections.Generic.List[System.Object]]::new()
     }

--- a/Public/Compare-List.ps1
+++ b/Public/Compare-List.ps1
@@ -85,10 +85,10 @@ function Compare-List {
                 $new = New-Object -TypeName psobject
                 if ( $sameList[$i] ) { $new | Add-Member -MemberType NoteProperty -Name 'DUPLICATES' -Value $sameList[$i] }
                 else { $new | Add-Member -MemberType NoteProperty -Name 'DUPLICATES' -Value '=>' }
-                if ( $header1List[$i] ) { $new | Add-Member -MemberType NoteProperty -Name "$header1" -Value $header1List[$i] }
-                else { $new | Add-Member -MemberType NoteProperty -Name "$header1" -Value '<>' }
-                if ( $header2List[$i] ) { $new | Add-Member -MemberType NoteProperty -Name "$header2" -Value $header2List[$i] }
-                else { $new | Add-Member -MemberType NoteProperty -Name "$header2" -Value '<=' }
+                if ( $header1List[$i] ) { $new | Add-Member -MemberType NoteProperty -Name $header1 -Value $header1List[$i] }
+                else { $new | Add-Member -MemberType NoteProperty -Name $header1 -Value '<>' }
+                if ( $header2List[$i] ) { $new | Add-Member -MemberType NoteProperty -Name $header2 -Value $header2List[$i] }
+                else { $new | Add-Member -MemberType NoteProperty -Name $header2 -Value '<=' }
                 $results.Add($new)
             }
         }

--- a/Public/Compress-URL.ps1
+++ b/Public/Compress-URL.ps1
@@ -30,7 +30,7 @@ function Compress-URL {
         [System.String] $ApiKey
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # SET REQUEST PARAMETERS

--- a/Public/Convert-Hexadecimal.ps1
+++ b/Public/Convert-Hexadecimal.ps1
@@ -30,7 +30,7 @@ function Convert-Hexadecimal {
         [System.String] $Decimal
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
 

--- a/Public/Convert-TimeZone.ps1
+++ b/Public/Convert-TimeZone.ps1
@@ -43,6 +43,8 @@ function Convert-TimeZone {
         [System.String] $TargetTimeZone = 'UTC'
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # FIND OS
         if ( $PSVersionTable.PSVersion.Major -lt 6 ) { $Windows = $true }
 

--- a/Public/ConvertFrom-GZipString.ps1
+++ b/Public/ConvertFrom-GZipString.ps1
@@ -25,7 +25,7 @@ function ConvertFrom-GZipString {
         [string[]] $String
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         foreach ($str in $String) {

--- a/Public/ConvertFrom-GZipString.ps1
+++ b/Public/ConvertFrom-GZipString.ps1
@@ -22,7 +22,7 @@ function ConvertFrom-GZipString {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, ValueFromPipeline)]
-        [string[]] $String
+        [System.String[]] $String
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/ConvertFrom-IISLog.ps1
+++ b/Public/ConvertFrom-IISLog.ps1
@@ -23,7 +23,7 @@ function ConvertFrom-IISLog {
         [System.String] $Path
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
 

--- a/Public/ConvertTo-FlatObject.ps1
+++ b/Public/ConvertTo-FlatObject.ps1
@@ -95,21 +95,21 @@ function ConvertTo-FlatObject {
                         elseif ($Item -isnot [Array] -and $Item -isnot [System.Collections.IEnumerable]) {
                             foreach ($Prop in $Item.PSObject.Properties) {
                                 if ($Prop.IsGettable -and $Prop.Name -notin $ExcludeProperty) {
-                                    $NewObject["$($Prop.Name)"] = $Item.$($Prop.Name)
+                                    $NewObject[$Prop.Name] = $Item.$($Prop.Name)
                                 }
                             }
                         }
                         else {
                             $NewObject = $Item
                         }
-                        $Iterate["$i"] = $NewObject
+                        $Iterate[$i] = $NewObject
                         $i += 1
                     }
                 }
                 else {
                     foreach ($Prop in $obj.PSObject.Properties) {
                         if ($Prop.IsGettable -and $Prop.Name -notin $ExcludeProperty) {
-                            $Iterate["$($Prop.Name)"] = $obj.$($Prop.Name)
+                            $Iterate[$Prop.Name] = $obj.$($Prop.Name)
                         }
                     }
                 }
@@ -117,7 +117,7 @@ function ConvertTo-FlatObject {
             If ($Iterate.Keys.Count) {
                 foreach ($Key in $Iterate.Keys) {
                     if ($Key -notin $ExcludeProperty) {
-                        ConvertTo-FlatObject -Object @(, $Iterate["$Key"]) -Separator $Separator -Base $Base -Depth $Depth -Path ($Path + $Key) -OutputObject $OutputObject -ExcludeProperty $ExcludeProperty
+                        ConvertTo-FlatObject -Object @(, $Iterate[$Key]) -Separator $Separator -Base $Base -Depth $Depth -Path ($Path + $Key) -OutputObject $OutputObject -ExcludeProperty $ExcludeProperty
                     }
                 }
             }

--- a/Public/ConvertTo-FlatObject.ps1
+++ b/Public/ConvertTo-FlatObject.ps1
@@ -59,7 +59,7 @@ function ConvertTo-FlatObject {
         [System.Collections.IDictionary] $OutputObject
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         $InputObjects = [System.Collections.Generic.List[Object]]::new()
     }

--- a/Public/ConvertTo-Hex.ps1
+++ b/Public/ConvertTo-Hex.ps1
@@ -26,7 +26,7 @@ function ConvertTo-Hex {
     )
     Begin {
         # OUTPUT VERBOSE MESSAGE
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # LOOP ALL INPUT

--- a/Public/ConvertTo-MarkdownTable.ps1
+++ b/Public/ConvertTo-MarkdownTable.ps1
@@ -25,7 +25,7 @@ function ConvertTo-MarkdownTable {
         [System.Object] $InputObject
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         $headersDone = $false
         $pattern = '(?<!\\)\|'  # escape every '|' unless already escaped

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -41,7 +41,7 @@ function Expand-GZip {
         [Switch] $Force
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # CHECK FOR DESTINATION PATH

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -38,7 +38,7 @@ function Expand-GZip {
         [System.IO.DirectoryInfo] $OutputDirectory,
 
         [Parameter(Mandatory = $false, HelpMessage = 'Overwrite the destination file if it already exists')]
-        [Switch] $Force
+        [System.Management.Automation.SwitchParameter] $Force
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/Expand-GZip.ps1
+++ b/Public/Expand-GZip.ps1
@@ -57,7 +57,7 @@ function Expand-GZip {
         # REFUSE TO OVERWRITE AN EXISTING DESTINATION UNLESS -Force WAS PASSED
         if ((Test-Path -Path $destFullPath -PathType Leaf) -and -not $Force) {
             $errParams = @{
-                Message     = "Destination file [$destFullPath] already exists. Use -Force to overwrite."
+                Message     = 'Destination file [{0}] already exists. Use -Force to overwrite.' -f $destFullPath
                 Category    = 'ResourceExists'
                 ErrorAction = 'Stop'
             }

--- a/Public/Expand-URL.ps1
+++ b/Public/Expand-URL.ps1
@@ -30,7 +30,7 @@ function Expand-URL {
         [System.String] $ApiKey
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # SET REQUEST PARAMETERS

--- a/Public/Export-NPMAudit.ps1
+++ b/Public/Export-NPMAudit.ps1
@@ -30,6 +30,8 @@ function Export-NPMAudit {
         [System.String] $OutputDirectory = "$HOME\Desktop"
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # GET CONTENT FROM NPM AUDIT FILE
         $json = Get-Content -Path $Path | ConvertFrom-Json
 

--- a/Public/Export-NPMAudit.ps1
+++ b/Public/Export-NPMAudit.ps1
@@ -27,7 +27,7 @@ function Export-NPMAudit {
 
         [Parameter(HelpMessage = 'Path to output directory')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
-        [System.String] $OutputDirectory = "$HOME\Desktop"
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop')
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/Export-SQLVAReport.ps1
+++ b/Public/Export-SQLVAReport.ps1
@@ -47,6 +47,8 @@ function Export-SQLVAReport {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # IMPORT REQUIRED MODULES
         Import-Module -Name SqlServer -ErrorAction Stop
 

--- a/Public/Export-SQLVAReportAggregate.ps1
+++ b/Public/Export-SQLVAReportAggregate.ps1
@@ -29,7 +29,7 @@ function Export-SQLVAReportAggregate {
             Mandatory, ParameterSetName = 'folder',
             HelpMessage = 'Path to directory of SQL Vulnerability Assessemnt file(s)'
         )]
-        [ValidateScript({ Test-Path -Path "$_\*" -Include "*.xlsx" })]
+        [ValidateScript({ Test-Path -Path (Join-Path -Path $_ -ChildPath '*') -Include '*.xlsx' })]
         [Alias('IP', 'Directory')]
         [System.String] $InputPath,
 
@@ -62,13 +62,13 @@ function Export-SQLVAReportAggregate {
 
         # WRITE TO DESKTOP IF DESTINATIONPATH NOT PROVIDED
         if ( -not $PSBoundParameters.ContainsKey('DestinationPath') ) {
-            $DestinationPath = Join-Path -Path "$HOME\Desktop" -ChildPath ('Aggregate-SQL-Scans_{0:yyyy-MM}.xlsx' -f (Get-Date))
+            $DestinationPath = Join-Path -Path (Join-Path -Path $HOME -ChildPath 'Desktop') -ChildPath ('Aggregate-SQL-Scans_{0:yyyy-MM}.xlsx' -f (Get-Date))
         }
 
         # GET REPORTS FROM ZIP
         if ( $PSBoundParameters.ContainsKey('ZipPath') ) {
             # EXTRACT FILES
-            Expand-Archive -Path $ZipPath -DestinationPath ($ExpandPath = "$HOME\Desktop\Extract")
+            Expand-Archive -Path $ZipPath -DestinationPath ($ExpandPath = (Join-Path -Path (Join-Path -Path $HOME -ChildPath 'Desktop') -ChildPath 'Extract'))
 
             # RESET INPUTPATH VAR
             $InputPath = $ExpandPath

--- a/Public/Export-SQLVAReportAggregate.ps1
+++ b/Public/Export-SQLVAReportAggregate.ps1
@@ -52,6 +52,8 @@ function Export-SQLVAReportAggregate {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # IMPORT REQUIRED MODULE
         Import-Module -Name ImportExcel
 

--- a/Public/Export-ScanReportAggregate.ps1
+++ b/Public/Export-ScanReportAggregate.ps1
@@ -36,7 +36,7 @@ function Export-ScanReportAggregate {
         [Parameter(Mandatory = $false)]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
         [Alias('DestinationPath')]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory = $false)]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Include "*.csv" })]

--- a/Public/Export-ScanReportAggregate.ps1
+++ b/Public/Export-ScanReportAggregate.ps1
@@ -61,6 +61,8 @@ function Export-ScanReportAggregate {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # PROVIDE HELP FOR THE USER WHEN NO SCANS ARE DECLARED
         $requiredParams = @('NessusSystemScan', 'NessusWebScan', 'AlertLogicWebScan', 'DatabaseScan', 'AcunetixScan')
         foreach ( $param in $requiredParams ) {

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -59,6 +59,8 @@ function Export-ScanReportSummary {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # CREATE MASTER LIST
         $summaryObjects = [System.Collections.Generic.List[System.Object]]::new()
         $summaryReport = @()

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -124,7 +124,7 @@ function Export-ScanReportSummary {
         # SET DESTINATION PATH
         if ( -not $PSBoundParameters.ContainsKey('DestinationPath') ) {
             $fileName = 'Summary-Scans_{0:yyyy-MM}.xlsx' -f (Get-Date)
-            $DestinationPath = Join-Path -Path "$HOME\Desktop" -ChildPath $fileName
+            $DestinationPath = Join-Path -Path (Join-Path -Path $HOME -ChildPath 'Desktop') -ChildPath $fileName
         }
         else {
             # GET LAST MONTH'S REPORT IF EXISTS

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -67,7 +67,7 @@ function Export-ScanReportSummary {
 
         # NORMALIZE RISK VALUES TO HIGH, MEDIUM, LOW OR BLANK
         $normalizeRisk = {
-            param([object]$Value)
+            param([System.Object]$Value)
 
             if ($null -eq $Value) { return '' }
 
@@ -85,7 +85,7 @@ function Export-ScanReportSummary {
 
         # MAP CVSS SCORE TO A 3-TIER RISK
         $riskFromCvss = {
-            param([object]$Score)
+            param([System.Object]$Score)
 
             if ($null -eq $Score) { return '' }
 

--- a/Public/Export-VeracodeReport.ps1
+++ b/Public/Export-VeracodeReport.ps1
@@ -30,6 +30,8 @@ function Export-VeracodeReport {
         [System.String] $OutputDirectory = "$HOME\Desktop"
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         [xml] $xml = Get-Content -Path $VeracodeXML
         #Write-Output $xml.detailedreport.severity
 

--- a/Public/Export-VeracodeReport.ps1
+++ b/Public/Export-VeracodeReport.ps1
@@ -27,7 +27,7 @@ function Export-VeracodeReport {
 
         [Parameter(HelpMessage = 'Output directory')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
-        [System.String] $OutputDirectory = "$HOME\Desktop"
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop')
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/Export-WebScan.ps1
+++ b/Public/Export-WebScan.ps1
@@ -27,7 +27,7 @@ function Export-WebScan {
 
         [Parameter(HelpMessage = 'Path to output directory')]
         [ValidateScript({ Test-Path -Path $_ -PathType Container })]
-        [System.String] $OutputDirectory = "$HOME\Desktop"
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop')
     )
 
     Begin {

--- a/Public/Export-WebScan.ps1
+++ b/Public/Export-WebScan.ps1
@@ -31,6 +31,8 @@ function Export-WebScan {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         function Get-Severity {
             <# =====================================================================
             .SYNOPSIS

--- a/Public/Export-WebScan.ps1
+++ b/Public/Export-WebScan.ps1
@@ -55,7 +55,7 @@ function Export-WebScan {
             Param(
                 [Parameter(Mandatory, HelpMessage = 'CVSS v3 Score')]
                 [ValidateNotNullOrEmpty()]
-                [double] $Score
+                [System.Double] $Score
             )
 
             $severity = switch ( $Score ) {

--- a/Public/Find-ServerPendingReboot.ps1
+++ b/Public/Find-ServerPendingReboot.ps1
@@ -26,6 +26,8 @@
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         if (-not $IsWindows) { Write-Error -Message 'Find-ServerPendingReboot requires Windows.' -ErrorAction Stop }
 
         # THE REGISTRY KEYS BELOW CONTAIN VALUES THAT DETERMINE WHETHER A SYSTEM REQUIRES A REBOOT

--- a/Public/Find-ServerPendingReboot.ps1
+++ b/Public/Find-ServerPendingReboot.ps1
@@ -31,14 +31,14 @@
         if (-not $IsWindows) { Write-Error -Message 'Find-ServerPendingReboot requires Windows.' -ErrorAction Stop }
 
         # THE REGISTRY KEYS BELOW CONTAIN VALUES THAT DETERMINE WHETHER A SYSTEM REQUIRES A REBOOT
-        $pendFileKeyPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\"
-        $autoUpdateKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update"
-        $CBSKeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\"
+        $pendFileKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\'
+        $autoUpdateKeyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update'
+        $CBSKeyPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\'
 
         $sbRemote = @{
             PendingFile = { Get-ItemProperty -Path $Using:pendFileKeyPath -Name PendingFileRenameOperations -ErrorAction SilentlyContinue }
-            AutoUpdate  = { Test-Path -Path "$Using:autoUpdateKeyPath\RebootRequired" }
-            CBS         = { Test-Path -Path "$Using:CBSKeyPath\RebootPending" }
+            AutoUpdate  = { Test-Path -Path ('{0}\RebootRequired' -f $Using:autoUpdateKeyPath) }
+            CBS         = { Test-Path -Path ('{0}\RebootPending' -f $Using:CBSKeyPath) }
         }
 
         # SYSTEMS GOVERNED BY SCCM 2012 CONTAIN ADDITIONAL VALUES TO KEEP TRACK OF REQUIRED REBOOT

--- a/Public/Find-WinEvent.ps1
+++ b/Public/Find-WinEvent.ps1
@@ -62,7 +62,7 @@ function Find-WinEvent {
         [System.String[]] $Data
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # CREATE EVENT LIST
         $eventList = for ($i = 0; $i -LT $EventTable.Count; $i++) {

--- a/Public/Get-ADUserStatus.ps1
+++ b/Public/Get-ADUserStatus.ps1
@@ -23,6 +23,8 @@ function Get-ADUserStatus {
         [System.String] $Identity
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         Import-Module -Name ActiveDirectory -ErrorAction Stop
     }
     Process {

--- a/Public/Get-ActiveGatewayUser.ps1
+++ b/Public/Get-ActiveGatewayUser.ps1
@@ -28,6 +28,8 @@ function Get-ActiveGatewayUser {
         [System.String] $ComputerName
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         if (-not $IsWindows) { Write-Error -Message 'Get-ActiveGatewayUser requires Windows.' -ErrorAction Stop }
 
         # SET QUERY PARAMS

--- a/Public/Get-AlternateDataStream.ps1
+++ b/Public/Get-AlternateDataStream.ps1
@@ -39,7 +39,7 @@ function Get-AlternateDataStream {
         [System.String] $Path = "*.*"
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET DESIRED PROPERTIES
         $props = @(

--- a/Public/Get-CVSSv3BaseScore.ps1
+++ b/Public/Get-CVSSv3BaseScore.ps1
@@ -25,6 +25,8 @@ function Get-CVSSv3BaseScore {
         [System.String[]] $CVE
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         $baseUri = "https://nvd.nist.gov/vuln/detail/{0}"
         $pattern = 'class="label\slabel-\w+">(\d+\.\d+)\s(\w+)</a>'
     }

--- a/Public/Get-CountryCode.ps1
+++ b/Public/Get-CountryCode.ps1
@@ -32,7 +32,7 @@ function Get-CountryCode {
         [System.String] $Country
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # CHECK FOR FILE SIGNATURE VARIABLE
         if (-Not (Get-Variable -Name 'CountryCodes' -ErrorAction Ignore)) {

--- a/Public/Get-CountryCode.ps1
+++ b/Public/Get-CountryCode.ps1
@@ -55,7 +55,7 @@ function Get-CountryCode {
             }
             '__cty' {
                 # MATCH COUNTRY
-                $CountryCodes.Where({ $_.'English short name' -Like "*$Country*" })
+                $CountryCodes.Where({ $_.'English short name' -Like ('*{0}*' -f $Country) })
             }
         }
     }

--- a/Public/Get-DirectoryReport.ps1
+++ b/Public/Get-DirectoryReport.ps1
@@ -47,6 +47,8 @@ function Get-DirectoryReport {
         [System.Management.Automation.SwitchParameter] $All
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # CREATE VARS
         $fileList = [System.Collections.Generic.List[System.Object]]::new()
         $folderList = [System.Collections.Generic.List[System.Object]]::new()

--- a/Public/Get-DirectoryReport.ps1
+++ b/Public/Get-DirectoryReport.ps1
@@ -136,26 +136,26 @@ function Get-DirectoryReport {
     End {
         # RETURN RESULTS
         $dir = (Get-Item $Path -Force).FullName
-        Write-Output -InputObject `n"Directory: $dir"`n
+        Write-Output -InputObject @('', ('Directory: {0}' -f $dir), '')
         if ( $fileList ) {
-            Write-Output -InputObject "Files greater than: $SizeInGb GB"
+            Write-Output -InputObject ('Files greater than: {0} GB' -f $SizeInGb)
             Write-Output -InputObject ( $fileList | Format-Table -AutoSize | Out-String )
         }
         if ( $folderList ) {
-            Write-Output -InputObject "Folders greater than: $SizeInGb GB"
+            Write-Output -InputObject ('Folders greater than: {0} GB' -f $SizeInGb)
             Write-Output -InputObject ( $folderList | Format-Table -AutoSize | Out-String )
         }
         if ( $warning ) { Write-Warning "One or more directories was not accessible!" }
 
         if ( $PSBoundParameters.ContainsKey('OutputDirectory') ) {
             $log = Join-Path -Path $OutputDirectory -ChildPath ('DirStats_{0:yyyyMMdd-HHmmss}.log' -f (Get-Date))
-            Set-Content -Path $log -Value `n"Directory: $dir"`n
+            Set-Content -Path $log -Value @('', ('Directory: {0}' -f $dir), '')
             if ( $fileList ) {
-                Add-Content -Path $log -Value "Files greater than: $SizeInGb GB"
+                Add-Content -Path $log -Value ('Files greater than: {0} GB' -f $SizeInGb)
                 Add-Content -Path $log -Value ( $fileList | Format-Table -AutoSize | Out-String )
             }
             if ( $folderList ) {
-                Add-Content -Path $log -Value "Folders greater than: $SizeInGb GB"
+                Add-Content -Path $log -Value ('Folders greater than: {0} GB' -f $SizeInGb)
                 Add-Content -Path $log -Value ( $folderList | Format-Table -AutoSize | Out-String )
             }
             if ( $warning ) { Add-Content -Path $log -Value "One or more directories was not accessible!" }

--- a/Public/Get-DomainRegistration.ps1
+++ b/Public/Get-DomainRegistration.ps1
@@ -32,7 +32,7 @@ function Get-DomainRegistration {
         [System.String] $ApiKey
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         $baseUrl = 'https://www.whoisxmlapi.com/whoisserver/WhoisService?apiKey={0}&domainName={1}'
         $headers = @{ accept = "application/json" }

--- a/Public/Get-EPSS.ps1
+++ b/Public/Get-EPSS.ps1
@@ -25,7 +25,7 @@ function Get-EPSS {
         [System.String[]] $CVE
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET BASE URI
         $baseUri = 'https://api.first.org/data/v1/epss'

--- a/Public/Get-FileHeader.ps1
+++ b/Public/Get-FileHeader.ps1
@@ -31,7 +31,7 @@ function Get-FileHeader {
         [System.Int16] $Bytes = 4
     )
     Process {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # GET BYTES OF FILE
         $fileBytes = [System.IO.File]::ReadAllBytes($Path)

--- a/Public/Get-FileInfo.ps1
+++ b/Public/Get-FileInfo.ps1
@@ -24,7 +24,7 @@ function Get-FileInfo {
         [System.String] $Signature
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # CHECK FOR FILE SIGNATURE VARIABLE
         if (-Not (Get-Variable -Name 'FileSignatures' -ErrorAction Ignore)) {

--- a/Public/Get-FolderSize.ps1
+++ b/Public/Get-FolderSize.ps1
@@ -64,7 +64,7 @@ function Get-FolderSize {
         [System.Management.Automation.SwitchParameter] $NoTotal
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # Get a list of all the directories in the base path we're looking for.
         $whereClause = if ($FolderName -eq 'all') { { $_.FullName -notin $OmitFolder } }

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -25,7 +25,7 @@ function Get-GreyNoiseIPStatus {
         https://greynoise.io
     #>
     [CmdletBinding()]
-    [OutputType([PSCustomObject])]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param (
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [System.Net.IPAddress[]] $IPAddress,
@@ -38,7 +38,7 @@ function Get-GreyNoiseIPStatus {
                 $true
             })] #>
         [ValidateLength(20, 100)]
-        [string] $ApiKey
+        [System.String] $ApiKey
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -41,6 +41,8 @@ function Get-GreyNoiseIPStatus {
         [string] $ApiKey
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # SET UP API REQUEST HEADERS AND BASE URL
         $headers = @{
             'Accept'       = 'application/json'

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -71,17 +71,17 @@ function Get-GreyNoiseIPStatus {
     Process {
         # LOOP THROUGH EACH IP ADDRESS AND QUERY GREYNOISE
         foreach ($ip in $IPAddress) {
-            Write-Verbose "Querying GreyNoise for IP: $ip"
+            Write-Verbose -Message ('Querying GreyNoise for IP: {0}' -f $ip)
 
             try {
                 # MAKE THE API REQUEST
-                $response = Invoke-RestMethod -Uri "$baseUrl/$ip" -Headers $headers -Method Get -ErrorAction Stop
+                $response = Invoke-RestMethod -Uri ('{0}/{1}' -f $baseUrl, $ip) -Headers $headers -Method Get -ErrorAction Stop
 
                 # DETERMINE STATUS BASED ON RESPONSE FIELDS
                 $noiseKey = if ($response.noise) { 'noise' } else { 'nonoise' }
                 $classKey = if ($response.classification) { $response.classification } else { 'default' }
-                $statusKey = if ($response.riot) { 'riot' } else { "$classKey|$noiseKey" }
-                $status = $statusTable[$statusKey] ?? $statusTable["default|$noiseKey"]
+                $statusKey = if ($response.riot) { 'riot' } else { '{0}|{1}' -f $classKey, $noiseKey }
+                $status = $statusTable[$statusKey] ?? $statusTable[('default|{0}' -f $noiseKey)]
 
                 # RETURN A CUSTOM OBJECT WITH THE RELEVANT DATA
                 [PSCustomObject] @{

--- a/Public/Get-Ipinfo.ps1
+++ b/Public/Get-Ipinfo.ps1
@@ -24,7 +24,7 @@ function Get-Ipinfo {
         [System.Net.IPAddress[]] $IPAddress
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         $baseUrl = "https://ipinfo.io/"
         $headers = @{ accept = "application/json" }

--- a/Public/Get-ItemAge.ps1
+++ b/Public/Get-ItemAge.ps1
@@ -69,8 +69,8 @@ function Get-ItemAge {
         $New | Add-Member -MemberType NoteProperty -Name "TotalVolume(GB)" -Value $Sum
         $New | Add-Member -MemberType NoteProperty -Name OldestFile -Value $OldestFile
         $New | Add-Member -MemberType NoteProperty -Name NewestFile -Value $NewestFile
-        $New | Add-Member -MemberType NoteProperty -Name "OlderThan$AgeInDays-Days" -Value $OldFileList.Count
-        $New | Add-Member -MemberType NoteProperty -Name "NewerThan$AgeInDays-Days" -Value $NewerFileList.Count
+        $New | Add-Member -MemberType NoteProperty -Name ('OlderThan{0}-Days' -f $AgeInDays) -Value $OldFileList.Count
+        $New | Add-Member -MemberType NoteProperty -Name ('NewerThan{0}-Days' -f $AgeInDays) -Value $NewerFileList.Count
 
         $New
     }

--- a/Public/Get-KEVList.ps1
+++ b/Public/Get-KEVList.ps1
@@ -71,7 +71,7 @@ function Get-KEVList {
         }
     }
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # VALIDATE OUTPUTDIRECTORY PARAMETER
         if ($PSBoundParameters.ContainsKey('OutputDirectory')) {

--- a/Public/Get-LatestPowerShell.ps1
+++ b/Public/Get-LatestPowerShell.ps1
@@ -29,7 +29,7 @@ function Get-LatestPowerShell {
         [System.String] $Architecture,
 
         [Parameter(Mandatory = $false, Position = 1, HelpMessage = 'Output directory')]
-        [System.String] $OutputDirectory = "$HOME\Desktop",
+        [System.String] $OutputDirectory = (Join-Path -Path $HOME -ChildPath 'Desktop'),
 
         [Parameter(Mandatory = $false, Position = 2, HelpMessage = 'Desired version of PowerShell')]
         [ValidatePattern('^\d(\.\d{1,2}){2}$')]

--- a/Public/Get-LatestPowerShell.ps1
+++ b/Public/Get-LatestPowerShell.ps1
@@ -36,7 +36,7 @@ function Get-LatestPowerShell {
         [System.String] $Version
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET URI HASH
         $uriHash = @{

--- a/Public/Get-LoggedOnUser.ps1
+++ b/Public/Get-LoggedOnUser.ps1
@@ -24,7 +24,7 @@ function Get-LoggedOnUser {
         [System.String] $ComputerName
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET SELF REFERENCE
         $self = @('localhost', '127.0.0.1', $env:COMPUTERNAME, '::1')

--- a/Public/Get-MsiInfo.ps1
+++ b/Public/Get-MsiInfo.ps1
@@ -25,7 +25,7 @@ function Get-MsiInfo {
         [System.IO.FileInfo] $Path
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         try {

--- a/Public/Get-PublicIP.ps1
+++ b/Public/Get-PublicIP.ps1
@@ -17,7 +17,7 @@ function Get-PublicIP {
     [CmdletBinding()]
     Param()
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # GET PUBLIC IP

--- a/Public/Get-QRCode.ps1
+++ b/Public/Get-QRCode.ps1
@@ -30,7 +30,7 @@ function Get-QRCode {
         [System.String] $ApiKey
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
     Process {
         # SET REQUEST PARAMETERS

--- a/Public/Get-RSOP.ps1
+++ b/Public/Get-RSOP.ps1
@@ -36,6 +36,8 @@ function Get-RSOP {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         Import-Module -Name GroupPolicy -ErrorAction Stop
     }
     Process {

--- a/Public/Get-SavedHistory.ps1
+++ b/Public/Get-SavedHistory.ps1
@@ -27,6 +27,8 @@ function Get-SavedHistory {
         [System.String] $Search
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         $where = { $_ -like "*$Search*" -and $_ -notmatch 'HistorySavePath' -and $_ -notmatch 'SavedHistory' }
         $history = Get-Content -Path (Get-PSReadLineOption).HistorySavePath |
             Where-Object -FilterScript $where | Select-Object -Unique

--- a/Public/Get-SavedHistory.ps1
+++ b/Public/Get-SavedHistory.ps1
@@ -29,7 +29,7 @@ function Get-SavedHistory {
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
-        $where = { $_ -like "*$Search*" -and $_ -notmatch 'HistorySavePath' -and $_ -notmatch 'SavedHistory' }
+        $where = { $_ -like ('*{0}*' -f $Search) -and $_ -notmatch 'HistorySavePath' -and $_ -notmatch 'SavedHistory' }
         $history = Get-Content -Path (Get-PSReadLineOption).HistorySavePath |
             Where-Object -FilterScript $where | Select-Object -Unique
     }

--- a/Public/Get-Software.ps1
+++ b/Public/Get-Software.ps1
@@ -43,6 +43,8 @@ function Get-Software {
         [System.Management.Automation.SwitchParameter] $All
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         if (-not $IsWindows) { Write-Error -Message 'Get-Software requires Windows.' -ErrorAction Stop }
 
         # SET VARS FOR REMOTE CALLS

--- a/Public/Get-Weather.ps1
+++ b/Public/Get-Weather.ps1
@@ -31,7 +31,7 @@ function Get-Weather {
         [System.String] $Format
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         New-Variable -Name 'base_uri' -Value 'https://wttr.in/' -Option ReadOnly
         $uri = $base_uri

--- a/Public/Get-Weather.ps1
+++ b/Public/Get-Weather.ps1
@@ -38,7 +38,7 @@ function Get-Weather {
 
         if ($PSBoundParameters.ContainsKey('City')) {
             $fCity = $City.Replace(' ', '+')
-            $uri += "$fCity"
+            $uri += $fCity
         }
         if ($PSBoundParameters.ContainsKey('Format')) {
             if ($Format -IN 1..4) { $uri += '?format={0}' -f $Format }

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -28,7 +28,7 @@ function Get-WhoIs {
         [System.Net.IPAddress[]] $IPAddress
     )
     Begin {
-        Write-Verbose "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
         $baseURL = 'http://whois.arin.net/rest'
         #default is XML anyway
         $header = @{ "Accept" = "application/xml" }

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -36,7 +36,7 @@ function Get-WhoIs {
     } #begin
     Process {
         foreach ( $ip in $IPAddress ) {
-            Write-Verbose -Message "Getting WhoIs information for $ip"
+            Write-Verbose -Message ('Getting WhoIs information for {0}' -f $ip)
             $url = '{0}/ip/{1}' -f $baseURL, $ip
             try {
                 $r = Invoke-Restmethod -Uri $url -Headers $header -ErrorAction Stop
@@ -57,13 +57,13 @@ function Get-WhoIs {
                     City                   = (Invoke-RestMethod $r.net.orgRef.'#text').org.city
                     StartAddress           = $r.net.startAddress
                     EndAddress             = $r.net.endAddress
-                    NetBlocks              = $r.net.netBlocks.netBlock | foreach-object { "$($_.startaddress)/$($_.cidrLength)" }
+                    NetBlocks              = $r.net.netBlocks.netBlock | ForEach-Object { '{0}/{1}' -f $_.startaddress, $_.cidrLength }
                     Updated                = $r.net.updateDate -as [datetime]
                 }
             } #If $r.net
         }
     } #Process
     End {
-        Write-Verbose "Ending $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Ending {0}' -f $MyInvocation.MyCommand)
     } #end
 }

--- a/Public/Get-WinInfo.ps1
+++ b/Public/Get-WinInfo.ps1
@@ -38,7 +38,7 @@ function Get-WinInfo {
         [System.String] $ComputerName
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         if (-not $IsWindows) { Write-Error -Message 'Get-WinInfo requires Windows.' -ErrorAction Stop }
 

--- a/Public/Get-WindowsEventCatalog.ps1
+++ b/Public/Get-WindowsEventCatalog.ps1
@@ -22,7 +22,7 @@ function Get-WindowsEventCatalog {
         [System.Management.Automation.SwitchParameter] $UseRemoteData
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET REMOTE PATH
         $uri = 'https://gist.githubusercontent.com/johnsarie27/5519dd08bae06b8b6271ac168e28e06a/raw/321c3a46756beb021012df4f2e26cccbd7fe6417/windows_signatures_850.csv'

--- a/Public/Get-WindowsEventCatalog.ps1
+++ b/Public/Get-WindowsEventCatalog.ps1
@@ -28,7 +28,7 @@ function Get-WindowsEventCatalog {
         $uri = 'https://gist.githubusercontent.com/johnsarie27/5519dd08bae06b8b6271ac168e28e06a/raw/321c3a46756beb021012df4f2e26cccbd7fe6417/windows_signatures_850.csv'
 
         # SET LOCAL PATH
-        $path = "$PSScriptRoot\..\Private\windows_signatures_850.csv"
+        $path = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'Private' | Join-Path -ChildPath 'windows_signatures_850.csv'
     }
     Process {
         # GET DATA

--- a/Public/Install-GitHubModule.ps1
+++ b/Public/Install-GitHubModule.ps1
@@ -36,7 +36,7 @@ function Install-GitHubModule {
         [System.String] $Scope = 'CurrentUser'
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET PLATFORM VARIABLES
         if ($IsWindows) { $tempDir = $env:TEMP; $splitChar = ';' }

--- a/Public/Install-GitHubModule.ps1
+++ b/Public/Install-GitHubModule.ps1
@@ -45,8 +45,8 @@ function Install-GitHubModule {
 
         # SET DEFAULT MODULE HOME PATH
         $moduleHome = switch ($Scope) {
-            'CurrentUser' { ($env:PSModulePath.Split("$splitChar"))[0] }
-            'AllUsers' { ($env:PSModulePath.Split("$splitChar"))[1] }
+            'CurrentUser' { ($env:PSModulePath.Split($splitChar))[0] }
+            'AllUsers' { ($env:PSModulePath.Split($splitChar))[1] }
         }
 
         Write-Verbose -Message ('Module home: [{0}]' -f $moduleHome)

--- a/Public/Install-ModuleFromZip.ps1
+++ b/Public/Install-ModuleFromZip.ps1
@@ -48,8 +48,8 @@ function Install-ModuleFromZip {
 
         # SET DEFAULT MODULE HOME PATH
         $moduleHome = switch ($Scope) {
-            'CurrentUser' { ($env:PSModulePath.Split("$splitChar"))[0] }
-            'AllUsers' { ($env:PSModulePath.Split("$splitChar"))[1] }
+            'CurrentUser' { ($env:PSModulePath.Split($splitChar))[0] }
+            'AllUsers' { ($env:PSModulePath.Split($splitChar))[1] }
         }
 
         Write-Verbose -Message ('Module home: [{0}]' -f $moduleHome)
@@ -92,7 +92,7 @@ function Install-ModuleFromZip {
 
         if ($getModule) {
             # THE MODULE IS ALREADY INSTALLED
-            $versionList = $getModule | ForEach-Object { "$($_.Version)" }
+            $versionList = $getModule | ForEach-Object { $_.Version.ToString() }
             Write-Warning -Message ('Module [{0}] identified. Installed version(s): [{1}]' -f $moduleInfo.ModuleName, ($versionList -join ', '))
 
             # CHECK FOR INPUT VERSION

--- a/Public/Install-ModuleFromZip.ps1
+++ b/Public/Install-ModuleFromZip.ps1
@@ -39,7 +39,7 @@ function Install-ModuleFromZip {
         [System.Management.Automation.SwitchParameter] $Replace
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET PLATFORM VARIABLES. THIS SHOULD WORK ON WINDOWS POWERSHELL 5.1 AND CORE
         if ($IsLinux) { $tempDir = '/tmp/'; $splitChar = ':' }

--- a/Public/Invoke-NetScan.ps1
+++ b/Public/Invoke-NetScan.ps1
@@ -30,6 +30,8 @@ function Invoke-NetScan {
     )
 
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         $ping = New-Object System.Net.NetworkInformation.Ping
         $count = 1
     }

--- a/Public/New-RandomString.ps1
+++ b/Public/New-RandomString.ps1
@@ -50,7 +50,7 @@ function New-RandomString {
         [System.Management.Automation.SwitchParameter] $ExcludeSpecial
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # CHECK FOR VALID PARAMETERS
         if ($ExcludeNumber -AND $ExcludeLowercase -AND $ExcludeUppercase -AND $ExcludeSpecial) {

--- a/Public/Out-MeasureResult.ps1
+++ b/Public/Out-MeasureResult.ps1
@@ -44,6 +44,8 @@ function Out-MeasureResult {
         [System.Timespan[]] $Measurement
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         # CREATE LIST COLLECTION
         $list = [System.Collections.Generic.List[System.TimeSpan]]::new()
     }

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -49,6 +49,8 @@ function Save-KBFile {
         [System.String] $Architecture = 'x64'
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         function Get-KBLink {
             Param(
                 [Parameter(Mandatory)]

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -66,10 +66,10 @@ function Save-KBFile {
                 if ( $i.type -eq 'Button' -and $i.Value -eq 'Download' ) { $i.ID }
             }
 
-            Write-Verbose -Message "$kbids"
+            Write-Verbose -Message ($kbids -join ' ')
 
             if (-not $kbids) {
-                Write-Warning -Message "No results found for $Name"
+                Write-Warning -Message ('No results found for {0}' -f $Name)
             }
 
             $guids = foreach ( $i in $results.Links ) {
@@ -79,19 +79,19 @@ function Save-KBFile {
             }
 
             if (-not $guids) {
-                Write-Warning -Message "No file found for $Name"
+                Write-Warning -Message ('No file found for {0}' -f $Name)
             }
 
             $splat = @{ Uri = ('{0}DownloadDialog.aspx' -f $msUpdate); Method = 'Post' }
             foreach ($guid in $guids) {
-                Write-Verbose -Message "Downloading information for $guid"
+                Write-Verbose -Message ('Downloading information for {0}' -f $guid)
                 $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
-                $splat['Body'] = @{ updateIDs = "[$post]" }
+                $splat['Body'] = @{ updateIDs = ('[{0}]' -f $post) }
                 $data = (Invoke-WebRequest @splat).Content
                 $links = Select-String -InputObject $data -AllMatches -Pattern $pattern | Select-Object -Unique
 
                 if (-not $links) {
-                    Write-Warning -Message "No file found for $Name"
+                    Write-Warning -Message ('No file found for {0}' -f $Name)
                 }
 
                 foreach ($link in $links) { $link.matches.value }
@@ -107,7 +107,7 @@ function Save-KBFile {
             $links = Get-KBLink -Name $kb
 
             if ($links.Count -gt 1 -and $Architecture -ne "All") {
-                $templinks = $links | Where-Object { $PSItem -match "$($Architecture)_" }
+                $templinks = $links | Where-Object { $PSItem -match ('{0}_' -f $Architecture) }
                 if ($templinks) {
                     $links = $templinks
                 }
@@ -124,16 +124,16 @@ function Save-KBFile {
                     $Path = Split-Path -Path $FilePath
                 }
 
-                $file = "$Path$([IO.Path]::DirectorySeparatorChar)$FilePath"
+                $file = Join-Path -Path $Path -ChildPath $FilePath
 
                 if ((Get-Command Start-BitsTransfer -ErrorAction Ignore)) {
                     Start-BitsTransfer -Source $link -Destination $file
                 }
                 else {
                     # Invoke-WebRequest is crazy slow for large downloads
-                    Write-Progress -Activity "Downloading $FilePath" -Id 1
+                    Write-Progress -Activity ('Downloading {0}' -f $FilePath) -Id 1
                     (New-Object Net.WebClient).DownloadFile($link, $file)
-                    Write-Progress -Activity "Downloading $FilePath" -Id 1 -Completed
+                    Write-Progress -Activity ('Downloading {0}' -f $FilePath) -Id 1 -Completed
                 }
                 if (Test-Path -Path $file) {
                     Get-ChildItem -Path $file

--- a/Public/Set-GitHubBranchProtection.ps1
+++ b/Public/Set-GitHubBranchProtection.ps1
@@ -86,7 +86,7 @@ function Set-GitHubBranchProtection {
         [System.Management.Automation.SwitchParameter] $Force
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.MyCommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # VERIFY gh CLI IS AVAILABLE
         if (-not (Get-Command -Name 'gh' -ErrorAction SilentlyContinue)) {

--- a/Public/Test-Performance.ps1
+++ b/Public/Test-Performance.ps1
@@ -64,6 +64,6 @@ function Test-Performance {
         $results
     }
     End {
-        Write-Verbose -Message "Ending $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Ending {0}' -f $MyInvocation.MyCommand)
     }
 }

--- a/Public/Test-Performance.ps1
+++ b/Public/Test-Performance.ps1
@@ -35,7 +35,7 @@ function Test-Performance {
         [System.Int32] $Iterations = 10
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # CREATE COLLECTION
         $measurements = [System.Collections.Generic.List[System.TimeSpan]]::new()

--- a/Public/Uninstall-MSI.ps1
+++ b/Public/Uninstall-MSI.ps1
@@ -23,7 +23,7 @@ function Uninstall-MSI {
         [System.String] $ProductId
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         if (-not $IsWindows) { Write-Error -Message 'Uninstall-MSI requires Windows.' -ErrorAction Stop }
 

--- a/Public/Update-GitHubModule.ps1
+++ b/Public/Update-GitHubModule.ps1
@@ -34,7 +34,7 @@ function Update-GitHubModule {
         [System.Management.Automation.SwitchParameter] $Replace
     )
     Begin {
-        Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         # SET PLATFORM TEMP
         $tempDir = if ($IsWindows) { $env:TEMP } elseif ($IsMacOS) { $Env:TMPDIR } else { '/tmp/' }

--- a/Public/Write-EncryptedFile.ps1
+++ b/Public/Write-EncryptedFile.ps1
@@ -39,6 +39,8 @@ function Write-EncryptedFile {
         [System.Byte[]] $KeyBytes
     )
     Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
         try {
             # If the key was provided as a string convert it to bytes
             if ( $Key ) { $KeyBytes = [byte[]] $Key.ToCharArray() }


### PR DESCRIPTION
## Summary

First slice of the alignment work tracked in #106 — addresses the **critical, pervasive** items only. The remaining high/medium findings will be split into follow-up PRs scoped from the same issue.

Scope is limited to standards compliance — no behavior changes, no new features.

Closes nothing on its own; #106 stays open to track the remaining work.

## Changes

- [x] **Begin-block opener** standardized across all 67 `Public/` files: every `Begin` now opens with `Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)`. Malformed variants (e.g. `Get-WhoIs.ps1:31` `"Starting $($MyInvocation.Mycommand)"`) corrected. Commit: df385e4.
- [x] **Double-quoted string interpolation** replaced with the `-f` format operator across 23 files. Help-block examples left untouched. Notable cleanups: `Get-DirectoryReport`'s malformed `` `n"..."`n `` backtick sequences fixed; `"$HOME\Desktop"` concatenations replaced with nested `Join-Path` for cross-platform safety; `Find-ServerPendingReboot` `$Using:` interpolations rewritten. Commit: aecb025.
- [x] **Type accelerators** replaced with full .NET names in `param()` blocks and `[OutputType()]` attributes (5 param files + 1 OutputType file). Inline casts deferred to follow-up. Commit: a274347.

PSScriptAnalyzer warning count unchanged across all three commits (4 pre-existing warnings).

## Validation

- [ ] CI green (`validate.yml`: Analyze + Test)
- [ ] `Import-Module ./SecurityTools.psd1 -Force` succeeds locally
- [ ] Spot-check a sample of changed functions still execute correctly

## Follow-up

Tracked in #106:
- High priority: missing `[OutputType()]` (13 files), missing `[CmdletBinding()]` (11 files), `.psm1` path handling, manifest `PowerShellVersion`.
- Medium: aliases, `SupportsShouldProcess` on `Write-EncryptedFile`, `ConvertTo-Json -Depth`, `return $value` removal.
- Deferred: inline type-accelerator casts across the module.
