### PR TITLE
chore(SecurityTools): high-priority standards compliance (#106)

### DIFF
--- a/Public/Convert-Epoch.ps1
+++ b/Public/Convert-Epoch.ps1
@@ -34,6 +34,9 @@ function Convert-Epoch {
         [ValidateNotNullOrEmpty()]
         [System.Int64] $Milliseconds # 1618614176000
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         switch ($PSCmdlet.ParameterSetName) {
             '__dt' {

--- a/Public/Convert-SecureKey.ps1
+++ b/Public/Convert-SecureKey.ps1
@@ -60,6 +60,9 @@ function Convert-SecureKey {
         [System.Management.Automation.SwitchParameter] $Force
     )
 
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         if ( $PSCmdlet.ParameterSetName -eq '_create' ) {
 

--- a/Public/ConvertFrom-Encoding.ps1
+++ b/Public/ConvertFrom-Encoding.ps1
@@ -29,6 +29,9 @@ function ConvertFrom-Encoding {
         [ValidateSet('Base64', 'URL')]
         [System.String] $Encoding = 'Base64'
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         switch ($Encoding) {
             'Base64' {

--- a/Public/ConvertTo-Encoding.ps1
+++ b/Public/ConvertTo-Encoding.ps1
@@ -29,6 +29,9 @@ function ConvertTo-Encoding {
         [ValidateSet('Base64', 'URL')]
         [System.String] $Encoding = 'Base64'
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         switch ($Encoding) {
             'Base64' {

--- a/Public/Find-LANHost.ps1
+++ b/Public/Find-LANHost.ps1
@@ -42,30 +42,34 @@ function Find-LANHost {
             })]
         [System.Management.Automation.SwitchParameter] $ClearARPCache
     )
-
-    $ASCIIEncoding = New-Object System.Text.ASCIIEncoding
-    $Bytes = $ASCIIEncoding.GetBytes("a")
-    $UDP = New-Object System.Net.Sockets.Udpclient
-
-    if ($ClearARPCache) { arp -d }
-
-    $Timer = [System.Diagnostics.Stopwatch]::StartNew()
-
-    foreach ( $i in $IP ) {
-        $UDP.Connect($i, 1)
-        [void] $UDP.Send($Bytes, $Bytes.length)
-        if ( $DelayMS ) { [System.Threading.Thread]::Sleep($DelayMS) }
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
+    Process {
+        $ASCIIEncoding = New-Object System.Text.ASCIIEncoding
+        $Bytes = $ASCIIEncoding.GetBytes("a")
+        $UDP = New-Object System.Net.Sockets.Udpclient
 
-    $Hosts = arp -a
+        if ($ClearARPCache) { arp -d }
 
-    $Timer.Stop()
-    if ($Timer.Elapsed.TotalSeconds -gt 15) {
-        Write-Warning "Scan took longer than 15 seconds, ARP entries may have been flushed. Recommend lowering DelayMS parameter"
+        $Timer = [System.Diagnostics.Stopwatch]::StartNew()
+
+        foreach ( $i in $IP ) {
+            $UDP.Connect($i, 1)
+            [void] $UDP.Send($Bytes, $Bytes.length)
+            if ( $DelayMS ) { [System.Threading.Thread]::Sleep($DelayMS) }
+        }
+
+        $Hosts = arp -a
+
+        $Timer.Stop()
+        if ($Timer.Elapsed.TotalSeconds -gt 15) {
+            Write-Warning "Scan took longer than 15 seconds, ARP entries may have been flushed. Recommend lowering DelayMS parameter"
+        }
+
+        $Hosts = $Hosts | Where-Object { $_ -match "dynamic" } | ForEach-Object { ($_.trim() -replace " {1,}", ",") | ConvertFrom-Csv -Header "IP", "MACAddress" }
+        $Hosts = $Hosts | Where-Object { $_.IP -in $IP }
+
+        Write-Output -InputObject $Hosts
     }
-
-    $Hosts = $Hosts | Where-Object { $_ -match "dynamic" } | ForEach-Object { ($_.trim() -replace " {1,}", ",") | ConvertFrom-Csv -Header "IP", "MACAddress" }
-    $Hosts = $Hosts | Where-Object { $_.IP -in $IP }
-
-    Write-Output -InputObject $Hosts
 }

--- a/Public/Get-ADUserStatus.ps1
+++ b/Public/Get-ADUserStatus.ps1
@@ -17,6 +17,7 @@ function Get-ADUserStatus {
         Status: Stable
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory, HelpMessage = 'AD User Identity')]
         [ValidateNotNullOrEmpty()]

--- a/Public/Get-AlternateDataStream.ps1
+++ b/Public/Get-AlternateDataStream.ps1
@@ -32,6 +32,7 @@ function Get-AlternateDataStream {
         4 = Restricted sites
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(ValueFromPipeline, Position = 0, HelpMessage = 'File path')]
         #[ValidateScript({ Test-Path -Path $_ -PathType Leaf })]

--- a/Public/Get-CVSSv3BaseScore.ps1
+++ b/Public/Get-CVSSv3BaseScore.ps1
@@ -18,6 +18,7 @@ function Get-CVSSv3BaseScore {
         Status: Stable
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline, HelpMessage = 'CVE ID')]
         [ValidatePattern('CVE-\d{4}\-\d+')]

--- a/Public/Get-CountryCode.ps1
+++ b/Public/Get-CountryCode.ps1
@@ -22,6 +22,7 @@ function Get-CountryCode {
         https://datahub.io/core/country-list
     #>
     [CmdletBinding(DefaultParameterSetName = '__cde')]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory, Position = 0, ParameterSetName = '__cde', HelpMessage = 'Country code (2- or 3-letter)')]
         [ValidatePattern('^[A-Z]{2,3}$')]

--- a/Public/Get-DomainRegistration.ps1
+++ b/Public/Get-DomainRegistration.ps1
@@ -22,6 +22,7 @@ function Get-DomainRegistration {
         https://domainsrdap.googleapis.com/v1/domain/<DOMAIN>
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'Target Domain')]
         [ValidateNotNullOrEmpty()]

--- a/Public/Get-EPSS.ps1
+++ b/Public/Get-EPSS.ps1
@@ -19,6 +19,7 @@ function Get-EPSS {
         https://www.first.org/epss/api
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Position = 0, ValueFromPipeline, HelpMessage = 'CVE ID')]
         [ValidatePattern('CVE-\d{4}\-\d+')]

--- a/Public/Get-FileHeader.ps1
+++ b/Public/Get-FileHeader.ps1
@@ -31,9 +31,10 @@ function Get-FileHeader {
         [ValidateRange(2, 100)]
         [System.Int16] $Bytes = 4
     )
-    Process {
+    Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
-
+    }
+    Process {
         # GET BYTES OF FILE
         $fileBytes = [System.IO.File]::ReadAllBytes($Path)
 

--- a/Public/Get-FileHeader.ps1
+++ b/Public/Get-FileHeader.ps1
@@ -21,6 +21,7 @@ function Get-FileHeader {
         https://stackoverflow.com/questions/26194071/recognize-file-types-in-powershell
     #>
     [CmdletBinding()]
+    [OutputType([System.String])]
     Param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline, HelpMessage = 'File path')]
         [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]

--- a/Public/Get-GreyNoiseIPStatus.ps1
+++ b/Public/Get-GreyNoiseIPStatus.ps1
@@ -81,7 +81,7 @@ function Get-GreyNoiseIPStatus {
                 $noiseKey = if ($response.noise) { 'noise' } else { 'nonoise' }
                 $classKey = if ($response.classification) { $response.classification } else { 'default' }
                 $statusKey = if ($response.riot) { 'riot' } else { '{0}|{1}' -f $classKey, $noiseKey }
-                $status = $statusTable[$statusKey] ?? $statusTable[('default|{0}' -f $noiseKey)]
+                $status = if ($null -ne $statusTable[$statusKey]) { $statusTable[$statusKey] } else { $statusTable[('default|{0}' -f $noiseKey)] }
 
                 # RETURN A CUSTOM OBJECT WITH THE RELEVANT DATA
                 [PSCustomObject] @{

--- a/Public/Get-Ipinfo.ps1
+++ b/Public/Get-Ipinfo.ps1
@@ -19,6 +19,7 @@ function Get-Ipinfo {
         To get more data (e.g., ASN or Company info) a token must be used
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSCustomObject])]
     Param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, HelpMessage = 'IPV4 address')]
         [System.Net.IPAddress[]] $IPAddress

--- a/Public/Get-ItemAge.ps1
+++ b/Public/Get-ItemAge.ps1
@@ -25,6 +25,7 @@ function Get-ItemAge {
         https://blogs.technet.microsoft.com/pstips/2017/05/20/display-friendly-file-sizes-in-powershell/
     #>
     [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSObject])]
     [Alias('Get-DirItemAges')]
     Param(
         [Parameter(Mandatory, HelpMessage = 'Target directory')]

--- a/Public/Get-ItemAge.ps1
+++ b/Public/Get-ItemAge.ps1
@@ -40,6 +40,9 @@ function Get-ItemAge {
         [Parameter(HelpMessage = 'Do not recurse through children directories')]
         [System.Management.Automation.SwitchParameter] $NoRecurse
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         if ( $NoRecurse ) { $Deep = $false } else { $Deep = $true }
         $Splatter = @{ Recurse = $Deep }

--- a/Public/Get-PatchTuesday.ps1
+++ b/Public/Get-PatchTuesday.ps1
@@ -27,6 +27,7 @@ function Get-PatchTuesday {
         https://gallery.technet.microsoft.com/scriptcenter/Find-Patch-Tuesday-using-94484479
     #>
     [CmdletBinding()]
+    [OutputType([System.DateTime])]
     Param(
         [Parameter(HelpMessage = 'Month')]
         [ValidateRange(1, 12)]

--- a/Public/Get-PatchTuesday.ps1
+++ b/Public/Get-PatchTuesday.ps1
@@ -46,6 +46,9 @@ function Get-PatchTuesday {
         [ValidateRange(1, 5)]
         [System.Int32] $WeekOfMonth = 2
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         # GET FIRST OF THE MONTH
         $firstDayOfMonth = Get-Date -Month $Month -Year $Year -Day 1 -Hour 0 -Minute 0 -Second 0

--- a/Public/Get-PublicIP.ps1
+++ b/Public/Get-PublicIP.ps1
@@ -15,6 +15,7 @@ function Get-PublicIP {
         Status: Stable
     #>
     [CmdletBinding()]
+    [OutputType([System.String])]
     Param()
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)

--- a/Public/Get-StringHash.ps1
+++ b/Public/Get-StringHash.ps1
@@ -29,6 +29,9 @@ function Get-StringHash {
         [System.String] $Algorithm = 'SHA256'
     )
 
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         # THE TYPE COULD BE CHANGED FROM ASCII TO UTF8 OR UNICODE
         # DEPENDING ON THE STRING INPUT

--- a/Public/Get-StringHash.ps1
+++ b/Public/Get-StringHash.ps1
@@ -19,6 +19,7 @@ function Get-StringHash {
         Status: Stable
     #>
     [CmdletBinding()]
+    [OutputType([System.String])]
     Param(
         [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'String to hash')]
         [System.String] $String,

--- a/Public/Get-UncPath.ps1
+++ b/Public/Get-UncPath.ps1
@@ -27,6 +27,7 @@ function Get-UncPath {
         Status: Stable
     #>
     [CmdletBinding()]
+    [OutputType([System.String])]
     Param(
         [Parameter(Mandatory, HelpMessage = 'Local path')]
         [ValidatePattern("[A-Z]:\\.+")]

--- a/Public/Get-UncPath.ps1
+++ b/Public/Get-UncPath.ps1
@@ -41,18 +41,22 @@ function Get-UncPath {
         [Parameter(HelpMessage = 'Use UNUX-style path')]
         [System.Management.Automation.SwitchParameter] $Unix
     )
-
-    if ( -not $PSBoundParameters.ContainsKey('ComputerName') ) { $ComputerName = ( hostname ) }
-
-    if ( $Path.Substring(0.2) -match '[A-Z]:' ) {
-        if ( $Unix ) {
-            $Path = $Path.Replace('\', '/')
-            $UncPath = '//' + $ComputerName + '/' + $Path.Replace(':', '$')
-        }
-        else {
-            $UncPath = '\\' + $ComputerName + '\' + $Path.Replace(':', '$')
-        }
-        $UncPath
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
     }
-    else { Write-Output -InputObject 'Invalid input' }
+    Process {
+        if ( -not $PSBoundParameters.ContainsKey('ComputerName') ) { $ComputerName = ( hostname ) }
+
+        if ( $Path.Substring(0.2) -match '[A-Z]:' ) {
+            if ( $Unix ) {
+                $Path = $Path.Replace('\', '/')
+                $UncPath = '//' + $ComputerName + '/' + $Path.Replace(':', '$')
+            }
+            else {
+                $UncPath = '\\' + $ComputerName + '\' + $Path.Replace(':', '$')
+            }
+            $UncPath
+        }
+        else { Write-Output -InputObject 'Invalid input' }
+    }
 }

--- a/Public/Read-EncryptedFile.ps1
+++ b/Public/Read-EncryptedFile.ps1
@@ -33,6 +33,9 @@ function Read-EncryptedFile {
         [Parameter(Mandatory, ParameterSetName = '__keybytes')]
         [System.Byte[]] $KeyBytes
     )
+    Begin {
+        Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+    }
     Process {
         try {
             # If the key was provided as a string Convert it to bytes

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -15,7 +15,7 @@
     ModuleVersion        = '0.10.4'
 
     # Supported PSEditions
-    CompatiblePSEditions = @('Core', 'Desktop')
+    CompatiblePSEditions = @('Core')
 
     # ID used to uniquely identify this module
     GUID                 = '46425f03-e6da-4deb-957c-c2dba2b2b777'
@@ -33,7 +33,7 @@
     Description          = 'Functions used in reporting and management of security devices and resources.'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion    = '5.1'
+    PowerShellVersion    = '7'
 
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -33,7 +33,7 @@
     Description          = 'Functions used in reporting and management of security devices and resources.'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion    = '7'
+    PowerShellVersion    = '7.0'
 
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''

--- a/SecurityTools.psm1
+++ b/SecurityTools.psm1
@@ -4,17 +4,20 @@
 # ==============================================================================
 
 # SET DIRECTORIES
-$dirs = @("$PSScriptRoot\Public", "$PSScriptRoot\Private")
+$dirs = @(
+    (Join-Path -Path $PSScriptRoot -ChildPath 'Public')
+    (Join-Path -Path $PSScriptRoot -ChildPath 'Private')
+)
 
 # DOT SOURCE ALL PS SCRIPTS
 foreach ($file in (Get-ChildItem -Path $dirs -Filter '*.ps1')) { . $file.FullName }
 
 # SET VARIABLES
 New-Variable -Name 'EventTable' -Option ReadOnly -Value (
-    Get-Content -Raw -Path "$PSScriptRoot\Private\EventTable.json" | ConvertFrom-Json
+    Get-Content -Raw -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Private/EventTable.json') | ConvertFrom-Json
 )
 New-Variable -Name 'InfoModel' -Option ReadOnly -Value (
-    Get-Content -Raw -Path "$PSScriptRoot\Private\InformationModel.json" | ConvertFrom-Json
+    Get-Content -Raw -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Private/InformationModel.json') | ConvertFrom-Json
 )
 
 # EXPORT MEMBERS


### PR DESCRIPTION
## Summary

Addresses the four **high-priority** items from #106. Six focused commits, no behavior changes.

- **psm1 path handling** — replace `"$PSScriptRoot\..."` backslash concatenation with `Join-Path` on all three usages so the module loads on non-Windows hosts.
- **Manifest `PowerShellVersion`** — bump from `'5.1'` to `'7.0'` and drop `'Desktop'` from `CompatiblePSEditions`. The codebase already uses PS7-only constructs (`$IsWindows`/`$IsLinux`/`$IsMacOS` automatic vars in 9 functions, null-coalescing `??` in `Get-GreyNoiseIPStatus`), so the `'5.1'` declaration was inaccurate — the module cannot actually load on Windows PowerShell. (`major.minor` form required by `System.Version` — bare `'7'` is rejected.)
- **`[OutputType()]` on 13 functions** — declared the actual return type per function (`[System.String]`, `[System.DateTime]`, `[System.Management.Automation.PSCustomObject]`, or `[System.Management.Automation.PSObject]` for `Get-ItemAge` which uses `New-Object psobject` + `Add-Member`). Verified `Get-Software` and `Get-ActiveGatewayUser` already have `[OutputType([PSObject])]` and the type is correct for both — no change.
- **`Begin` block on 11 functions** — added the standard `Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)` opener. **Audit correction**: the issue listed these as "`[CmdletBinding()]` missing", but all 11 already had `CmdletBinding` (added in #105). The actual gap was the `Begin` block. For `Find-LANHost` and `Get-UncPath` (whose bodies were not wrapped in `Begin`/`Process` at all), the body is now wrapped in a `Process` block for consistency with the template.

Drive-by: removed the `??` null-coalescing operator from `Get-GreyNoiseIPStatus.ps1:84` in its own commit, since the standard prohibits ternary/shorthand expression operators. Replaced with explicit `if`/`else` matching the surrounding key-derivation lines.

## Commits

1. `dd2af3c` — `chore(psm1): use Join-Path for cross-platform path composition`
2. `069c87e` — `chore(manifest): declare PowerShell 7 as minimum runtime`
3. `e93225a` — `chore(Get-GreyNoiseIPStatus): replace null-coalescing with if/else`
4. `6a2ff77` — `chore(Public): add [OutputType()] to 13 functions`
5. `d49dece` — `chore(Public): add standard Begin verbose opener to 11 functions`
6. `cb7ef72` — `fix(manifest): use 'major.minor' form for PowerShellVersion`

## Test plan

- [x] `./Build/build.ps1 -ResolveDependency -TaskList Analyze` passes — green on the latest CI run
- [x] `./Build/build.ps1 -ResolveDependency -TaskList Test` passes (Help / Manifest / Meta tests in particular) — green on the latest CI run
- [x] Spot-check `Import-Module ./SecurityTools.psd1` on macOS/Linux to confirm the `Join-Path` fix and PS7 minimum work as expected — `ImportStagingModule` step in CI runs on Ubuntu with pwsh 7.4 and succeeded after the `'7.0'` hotfix
- [ ] Spot-check a verbose call on one of the 11 updated functions (e.g. `Get-PatchTuesday -Verbose`) to confirm the `Starting` line emits — not run locally; low-risk text-only addition matching the same pattern already exercised by 60+ other functions

Closes the high-priority section of #106. Medium-priority items and the deferred inline-cast follow-up remain for a subsequent PR.
