### PR TITLE
chore(SecurityTools): medium-priority standards compliance (#106)

### DIFF
--- a/Public/Compare-List.ps1
+++ b/Public/Compare-List.ps1
@@ -69,12 +69,12 @@ function Compare-List {
 
             # NEED TO USE SELECT-OBJECT RATHER THAN $compSheet."$header1" BECAUSE OF THE HEADER "ITEM."
             # THIS SEEMS TO CALL A METHOD OR PROPERTY OF A PSCustomObject I WASN'T PREVIOUSLY AWARE OF
-            foreach ( $i in ($compSheet | Select-Object -EXP $header1) ) {
-                if ( ($compSheet | Select-Object -EXP $header2) -contains $i ) { $sameList += $i }
+            foreach ( $i in ($compSheet | Select-Object -ExpandProperty $header1) ) {
+                if ( ($compSheet | Select-Object -ExpandProperty $header2) -contains $i ) { $sameList += $i }
                 else { $header1List += $i }
             }
-            foreach ( $i in ($compSheet | Select-Object -EXP $header2) ) {
-                if ( ($compSheet | Select-Object -EXP $header1) -notcontains $i ) { $header2List += $i }
+            foreach ( $i in ($compSheet | Select-Object -ExpandProperty $header2) ) {
+                if ( ($compSheet | Select-Object -ExpandProperty $header1) -notcontains $i ) { $header2List += $i }
             }
 
             if ( $sameList.Count -gt $header1List.Count ) { $longest = $sameList }

--- a/Public/ConvertTo-FlatObject.ps1
+++ b/Public/ConvertTo-FlatObject.ps1
@@ -81,7 +81,7 @@ function ConvertTo-FlatObject {
                 If ($obj -is [System.Collections.IDictionary]) {
                     $Iterate = $obj
                 }
-                elseif ($obj -is [Array] -or $obj -is [System.Collections.IEnumerable]) {
+                elseif ($obj -is [System.Array] -or $obj -is [System.Collections.IEnumerable]) {
                     $i = $Base
                     foreach ($Item in $obj.GetEnumerator()) {
                         $NewObject = [ordered] @{}
@@ -92,7 +92,7 @@ function ConvertTo-FlatObject {
                                 }
                             }
                         }
-                        elseif ($Item -isnot [Array] -and $Item -isnot [System.Collections.IEnumerable]) {
+                        elseif ($Item -isnot [System.Array] -and $Item -isnot [System.Collections.IEnumerable]) {
                             foreach ($Prop in $Item.PSObject.Properties) {
                                 if ($Prop.IsGettable -and $Prop.Name -notin $ExcludeProperty) {
                                     $NewObject[$Prop.Name] = $Item.$($Prop.Name)

--- a/Public/ConvertTo-Hex.ps1
+++ b/Public/ConvertTo-Hex.ps1
@@ -35,7 +35,7 @@ function ConvertTo-Hex {
             # CONVERT CHARACTER (CHAR) TO HEX
             [PSCustomObject] @{
                 Char = $char
-                Hex  = '0x{0:X2}' -f [int]([byte][char]$char)
+                Hex  = '0x{0:X2}' -f [System.Int32]([System.Byte][System.Char]$char)
             }
         }
     }

--- a/Public/Export-ScanReportSummary.ps1
+++ b/Public/Export-ScanReportSummary.ps1
@@ -71,8 +71,8 @@ function Export-ScanReportSummary {
 
             if ($null -eq $Value) { return '' }
 
-            $text = [string]$Value
-            if ([string]::IsNullOrWhiteSpace($text)) { return '' }
+            $text = [System.String]$Value
+            if ([System.String]::IsNullOrWhiteSpace($text)) { return '' }
 
             switch -Regex ($text.Trim().ToLowerInvariant()) {
                 '^(none|no risk|informational|info|0)$' { '' ; break }
@@ -89,11 +89,11 @@ function Export-ScanReportSummary {
 
             if ($null -eq $Score) { return '' }
 
-            $scoreText = [string]$Score
-            if ([string]::IsNullOrWhiteSpace($scoreText)) { return '' }
+            $scoreText = [System.String]$Score
+            if ([System.String]::IsNullOrWhiteSpace($scoreText)) { return '' }
 
-            [double]$scoreValue = 0.0
-            $isInvariantParsed = [double]::TryParse(
+            $scoreValue = 0.0
+            $isInvariantParsed = [System.Double]::TryParse(
                 $scoreText,
                 [System.Globalization.NumberStyles]::Float,
                 [System.Globalization.CultureInfo]::InvariantCulture,
@@ -101,7 +101,7 @@ function Export-ScanReportSummary {
             )
 
             if (-not $isInvariantParsed) {
-                $isCurrentParsed = [double]::TryParse($scoreText, [ref]$scoreValue)
+                $isCurrentParsed = [System.Double]::TryParse($scoreText, [ref]$scoreValue)
                 if (-not $isCurrentParsed) { return '' }
             }
 
@@ -329,10 +329,10 @@ function Export-ScanReportSummary {
                     Name       = 'Risk'
                     Expression = {
                         $risk = & $riskFromCvss $_.'CVSS3 Score'
-                        if ([string]::IsNullOrWhiteSpace($risk)) {
+                        if ([System.String]::IsNullOrWhiteSpace($risk)) {
                             $risk = & $riskFromCvss $_.'CVSS Score'
                         }
-                        if ([string]::IsNullOrWhiteSpace($risk)) {
+                        if ([System.String]::IsNullOrWhiteSpace($risk)) {
                             $risk = $_.'Severity'
                         }
                         $risk

--- a/Public/Export-VeracodeReport.ps1
+++ b/Public/Export-VeracodeReport.ps1
@@ -32,7 +32,7 @@ function Export-VeracodeReport {
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
-        [xml] $xml = Get-Content -Path $VeracodeXML
+        [System.Xml.XmlDocument] $xml = Get-Content -Path $VeracodeXML
         #Write-Output $xml.detailedreport.severity
 
         $array = @()
@@ -80,7 +80,7 @@ function Export-VeracodeReport {
                 sev3flaws    = $module.numflawssev3
                 sev4flaws    = $module.numflawssev4
                 sev5flaws    = $module.numflawssev5
-                totalflaws   = [int] $module.numflawssev0 + [int] $module.numflawssev1 + [int] $module.numflawssev2 + [int] $module.numflawssev3 + [int] $module.numflawssev4 + [int] $module.numflawssev5
+                totalflaws   = [System.Int32] $module.numflawssev0 + [System.Int32] $module.numflawssev1 + [System.Int32] $module.numflawssev2 + [System.Int32] $module.numflawssev3 + [System.Int32] $module.numflawssev4 + [System.Int32] $module.numflawssev5
             }
         }
 

--- a/Public/Export-WebScan.ps1
+++ b/Public/Export-WebScan.ps1
@@ -70,7 +70,7 @@ function Export-WebScan {
             $severity
         }
 
-        [XML] $xml = Get-Content -Path $Path
+        [System.Xml.XmlDocument] $xml = Get-Content -Path $Path
         $report = [System.Collections.Generic.List[System.Object]]::new()
 
         $excelParams = @{
@@ -127,7 +127,7 @@ function Export-WebScan {
                 CVSS3Severity  = 'Unknown'
             }
 
-            if ( $new['CVSS3'] ) { $new['CVSS3Severity'] = Get-Severity -Score ([double] $new['CVSS3']) }
+            if ( $new['CVSS3'] ) { $new['CVSS3Severity'] = Get-Severity -Score ([System.Double] $new['CVSS3']) }
 
             $report.Add([PSCustomObject] $new)
         }

--- a/Public/Find-ServerPendingReboot.ps1
+++ b/Public/Find-ServerPendingReboot.ps1
@@ -64,7 +64,7 @@
                 $sbLocal = @{ }
                 foreach ( $k in $sbRemote.Keys ) {
                     $string = $sbRemote[$k] -replace 'Using:', ''
-                    $sbLocal[$k] = [Scriptblock]::Create($String)
+                    $sbLocal[$k] = [System.Management.Automation.ScriptBlock]::Create($String)
                 }
 
                 $key = Invoke-Command -ScriptBlock $sbLocal['PendingFile']

--- a/Public/Get-ItemAge.ps1
+++ b/Public/Get-ItemAge.ps1
@@ -47,8 +47,8 @@ function Get-ItemAge {
         if ( $NoRecurse ) { $Deep = $false } else { $Deep = $true }
         $Splatter = @{ Recurse = $Deep }
 
-        $Tot = Get-ChildItem $Path @Splatter | Measure-Object | Select-Object -exp Count
-        $Avg = [math]::round(((Get-ChildItem $Path @Splatter | Measure-Object -Property Length -Average | Select-Object -exp Average) / 1mb ), 2 )
+        $Tot = Get-ChildItem $Path @Splatter | Measure-Object | Select-Object -ExpandProperty Count
+        $Avg = [math]::round(((Get-ChildItem $Path @Splatter | Measure-Object -Property Length -Average | Select-Object -ExpandProperty Average) / 1mb ), 2 )
         $Sum = [math]::round(((Get-ChildItem $Path @Splatter | Measure-Object -Property Length -Sum).Sum / 1gb), 2)
 
         $OldestFile = Get-ChildItem $Path @Splatter | Sort-Object LastWriteTime | Select-Object -First 1 Name, LastWriteTime
@@ -67,7 +67,7 @@ function Get-ItemAge {
         $New | Add-Member -MemberType NoteProperty -Name Deep -Value $Deep
         $New | Add-Member -MemberType NoteProperty -Name Date -Value ( Get-Date )
         $New | Add-Member -MemberType NoteProperty -Name ComputerName -Value ( hostname )
-        $New | Add-Member -MemberType NoteProperty -Name Directory -Value (Get-Item $Path | Select-Object -EXP FullName)
+        $New | Add-Member -MemberType NoteProperty -Name Directory -Value (Get-Item $Path | Select-Object -ExpandProperty FullName)
         $New | Add-Member -MemberType NoteProperty -Name TotalFiles -Value $Tot
         $New | Add-Member -MemberType NoteProperty -Name "AverageFileSize(MB)" -Value $Avg
         $New | Add-Member -MemberType NoteProperty -Name "TotalVolume(GB)" -Value $Sum

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -58,7 +58,7 @@ function Get-WhoIs {
                     StartAddress           = $r.net.startAddress
                     EndAddress             = $r.net.endAddress
                     NetBlocks              = $r.net.netBlocks.netBlock | ForEach-Object { '{0}/{1}' -f $_.startaddress, $_.cidrLength }
-                    Updated                = $r.net.updateDate -as [datetime]
+                    Updated                = $r.net.updateDate -as [System.DateTime]
                 }
             } #If $r.net
         }

--- a/Public/Out-MeasureResult.ps1
+++ b/Public/Out-MeasureResult.ps1
@@ -50,7 +50,7 @@ function Out-MeasureResult {
         $list = [System.Collections.Generic.List[System.TimeSpan]]::new()
     }
     Process {
-        if ($Measurement -is [array]) { $list.AddRange($Measurement) }
+        if ($Measurement -is [System.Array]) { $list.AddRange($Measurement) }
         else { $list.Add($Measurement) }
     }
     End {
@@ -62,9 +62,9 @@ function Out-MeasureResult {
         $minObj = $list.Where( { $_.Ticks -eq $min } )
 
         [PSCustomObject] @{
-            MaxMilliseconds = [int] $maxObj.TotalMilliseconds
-            MinMilliseconds = [int] $minObj.TotalMilliseconds
-            AvgMilliseconds = [int] $avg.Average
+            MaxMilliseconds = [System.Int32] $maxObj.TotalMilliseconds
+            MinMilliseconds = [System.Int32] $minObj.TotalMilliseconds
+            AvgMilliseconds = [System.Int32] $avg.Average
         }
     }
 }

--- a/Public/Read-EncryptedFile.ps1
+++ b/Public/Read-EncryptedFile.ps1
@@ -39,10 +39,10 @@ function Read-EncryptedFile {
     Process {
         try {
             # If the key was provided as a string Convert it to bytes
-            if ( $Key ) { $KeyBytes = [byte[]]$Key.ToCharArray() }
+            if ( $Key ) { $KeyBytes = [System.Byte[]]$Key.ToCharArray() }
 
             # If the key is not 256 bits Pad it or truncate it as needed
-            if ( $KeyBytes.Count -ne 32 ) { $KeyBytes = ( $KeyBytes + [byte[]]'ThePaddingToUseIfWeNeedMoreBytes'.ToCharArray() )[0..31] }
+            if ( $KeyBytes.Count -ne 32 ) { $KeyBytes = ( $KeyBytes + [System.Byte[]]'ThePaddingToUseIfWeNeedMoreBytes'.ToCharArray() )[0..31] }
 
             # Create cryptography engine
             $crypto = New-Object -TypeName System.Security.Cryptography.RijndaelManaged

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -85,7 +85,7 @@ function Save-KBFile {
             $splat = @{ Uri = ('{0}DownloadDialog.aspx' -f $msUpdate); Method = 'Post' }
             foreach ($guid in $guids) {
                 Write-Verbose -Message ('Downloading information for {0}' -f $guid)
-                $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
+                $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress -Depth 4
                 $splat['Body'] = @{ updateIDs = ('[{0}]' -f $post) }
                 $data = (Invoke-WebRequest @splat).Content
                 $links = Select-String -InputObject $data -AllMatches -Pattern $pattern | Select-Object -Unique

--- a/Public/Write-EncryptedFile.ps1
+++ b/Public/Write-EncryptedFile.ps1
@@ -23,7 +23,7 @@ function Write-EncryptedFile {
         Status: Stable
         Originally written by Tim Curwick in PowerShell Conference Book 2
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     Param(
         [Parameter(Mandatory, ValueFromPipeLine)]
         [System.String[]] $Content,
@@ -40,6 +40,10 @@ function Write-EncryptedFile {
     )
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
+
+        # GATE FILE CREATION ON SHOULDPROCESS; SUPPRESSES -WhatIf / -Confirm DECLINE
+        $shouldWrite = $PSCmdlet.ShouldProcess($Path, 'Encrypt and write')
+        if (-not $shouldWrite) { return }
 
         try {
             # If the key was provided as a string convert it to bytes
@@ -83,6 +87,8 @@ function Write-EncryptedFile {
         $firstLine = $true
     }
     Process {
+        if (-not $shouldWrite) { return }
+
         try {
             foreach ( $line in $Content ) {
                 if ( $firstLine ) { $firstLine = $false }
@@ -103,6 +109,8 @@ function Write-EncryptedFile {
         }
     }
     End {
+        if (-not $shouldWrite) { return }
+
         # Clean up
         if ( $streamWriter ) { $streamWriter.Close() }
         if ( $cryptoStream ) { $cryptoStream.Close() }

--- a/Public/Write-EncryptedFile.ps1
+++ b/Public/Write-EncryptedFile.ps1
@@ -47,10 +47,10 @@ function Write-EncryptedFile {
 
         try {
             # If the key was provided as a string convert it to bytes
-            if ( $Key ) { $KeyBytes = [byte[]] $Key.ToCharArray() }
+            if ( $Key ) { $KeyBytes = [System.Byte[]] $Key.ToCharArray() }
 
             # If the key is not 256 bits pad it or truncate it as needed
-            if ( $KeyBytes.Count -ne 32 ) { $KeyBytes = ( $KeyBytes + [byte[]]'ThePaddingToUseIfWeNeedMoreBytes'.ToCharArray() )[0..31] }
+            if ( $KeyBytes.Count -ne 32 ) { $KeyBytes = ( $KeyBytes + [System.Byte[]]'ThePaddingToUseIfWeNeedMoreBytes'.ToCharArray() )[0..31] }
 
             # Create cryptography engine
             $crypto = New-Object -TypeName System.Security.Cryptography.RijndaelManaged

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion        = '0.10.4'
+    ModuleVersion        = '0.10.5'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')


### PR DESCRIPTION
## Summary

Tackles the Medium-priority block on #106. Four standards-compliance items, no behavior change.

## Changes

- **Aliases** — replaced `Select-Object -EXP/-exp` with `-ExpandProperty` in:
  - `Compare-List.ps1` (4 spots; the original audit hit)
  - `Get-ItemAge.ps1` (3 spots; audit extension — same violation pattern missed by the original sweep)
- **`SupportsShouldProcess`** on `Write-EncryptedFile.ps1` — mutates state (creates a file). Added `[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]` and gated the `Begin` block's `FileStream` creation behind `ShouldProcess`; `Process` and `End` short-circuit when declined. Verified `-WhatIf` no longer creates the target file.
- **`ConvertTo-Json -Depth`** added to `Save-KBFile.ps1:88`.

## Audit corrections (no change required)

- `Set-GitHubBranchProtection.ps1:128` already has `-Depth 6` (likely fixed in #107).
- `Write-EncryptedFile.ps1` has no `ConvertTo-Json` call; the only match was a comment-based help example.
- `Get-WhoIs.ps1:60` — lowercase `foreach-object` casing was already corrected in #105.
- `Get-KEVList.ps1` — the only `return` keyword is `return $paramDictionary` inside the `DynamicParam` block, which is the idiomatic pattern for returning the `RuntimeDefinedParameterDictionary` to the PowerShell engine (a control-flow return, not pipeline emission). The skill's prohibition on `return` for emit-to-pipeline does not apply here. No change.

## Test plan

- [x] `./Build/build.ps1 -TaskList 'CombineFunctionsAndStage','Analyze','Test'` — 668 passed, 0 failed, 2 skipped
- [x] PSScriptAnalyzer — no new warnings
- [x] Manual: `Write-EncryptedFile ... -WhatIf` does not create the target file; normal write path produces the file
- [ ] CI green