### PR TITLE
test(SecurityTools): expand thin Pester tests for 3 functions (refs #109)

### DIFF
--- a/Tests/Unit/Compare-List.tests.ps1
+++ b/Tests/Unit/Compare-List.tests.ps1
@@ -1,61 +1,94 @@
 BeforeDiscovery {
-    # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
-    # Import module
     if (-not (Get-Module -Name $env:BHProjectName)) {
         Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
     }
-    $Cmdlets = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
 }
 
-Describe -Name "Compare-List" -Fixture {
-    Context -Name "__list parameter set" -Fixture {
-        It -Name "compares two arrays of strings" -Test {
+Describe -Name 'Compare-List' -Fixture {
+
+    Context -Name '__list parameter set' -Fixture {
+        It -Name 'returns shared items under DUPLICATES' -Test {
             $a = 'run', 'jump', 'walk'
             $b = 'run', 'jump', 'swim', 'hike'
-            $compare = Compare-List -ListA $a -ListB $b
-            $compare.DUPLICATES | Should -Contain 'run'
+            $result = Compare-List -ListA $a -ListB $b
+            $result.DUPLICATES | Should -Contain 'run'
+            $result.DUPLICATES | Should -Contain 'jump'
         }
 
-        It -Name "compares two arrays of objects" -Test {
-            $a = Get-Process | Select-Object -First 5
-            $b = $a | Select-Object -First 2
-            $compare = Compare-List -ListA $a -ListB $b
-            $compare.'LIST-A' | Should -HaveCount 3
-        }
-
-        It -Name "should not throw an error" -Test {
+        It -Name 'returns items unique to ListA under LIST-A' -Test {
             $a = 'run', 'jump', 'walk'
+            $b = 'run', 'jump'
+            $result = Compare-List -ListA $a -ListB $b
+            $result.'LIST-A' | Should -Contain 'walk'
+        }
+
+        It -Name 'returns items unique to ListB under LIST-B' -Test {
+            $a = 'run', 'jump'
             $b = 'run', 'jump', 'swim', 'hike'
-            { Compare-List -ListA $a -ListB $b } | Should -Not -Throw
+            $result = Compare-List -ListA $a -ListB $b
+            $result.'LIST-B' | Should -Contain 'swim'
+            $result.'LIST-B' | Should -Contain 'hike'
+        }
+
+        It -Name 'rejects an empty ListA' -Test {
+            { Compare-List -ListA @() -ListB ('a') } | Should -Throw
+        }
+
+        It -Name 'rejects an empty ListB' -Test {
+            { Compare-List -ListA ('a') -ListB @() } | Should -Throw
+        }
+
+        It -Name 'returns a single row when the only overlap is one item' -Test {
+            $result = Compare-List -ListA @('a') -ListB @('a')
+            $result | Should -HaveCount 1
+            $result[0].DUPLICATES | Should -Be 'a'
         }
     }
 
-    Context -Name "__file parameter set" -Fixture {
-        It -Name "should not throw an error" -Test {
-            { Compare-List -Path $Path } | Should -Not -Throw
+    Context -Name '__file parameter set' -Fixture {
+        It -Name 'compares a well-formed two-column CSV' -Test {
+            $csvPath = Join-Path -Path $TestDrive -ChildPath 'two-col.csv'
+            @(
+                [PSCustomObject] @{ A = 'apple';  B = 'apple' }
+                [PSCustomObject] @{ A = 'banana'; B = 'cherry' }
+            ) | Export-Csv -Path $csvPath -NoTypeInformation
+
+            $result = Compare-List -Path $csvPath
+            $result.DUPLICATES | Should -Contain 'apple'
+            $result.A          | Should -Contain 'banana'
+            $result.B          | Should -Contain 'cherry'
         }
 
-        It -Name "compares string data in a csv" -Test {
-            $compare = Compare-List -Path $Path
-            $compare.Count | Should -Be ($a.Count - $b.Count)
+        It -Name 'warns and returns nothing for a one-column CSV' -Test {
+            $csvPath = Join-Path -Path $TestDrive -ChildPath 'one-col.csv'
+            @(
+                [PSCustomObject] @{ Only = 'x' }
+                [PSCustomObject] @{ Only = 'y' }
+            ) | Export-Csv -Path $csvPath -NoTypeInformation
+
+            $result = Compare-List -Path $csvPath -WarningAction SilentlyContinue
+            $result | Should -BeNullOrEmpty
         }
 
-        It -Name "contains accurate count in comparisson" -Test {
-            $compare = Compare-List -Path $Path
-            $compare.DUPLICATES | Should -Contain $b[0].ProcessName
+        It -Name 'warns and returns nothing for a three-column CSV' -Test {
+            $csvPath = Join-Path -Path $TestDrive -ChildPath 'three-col.csv'
+            @(
+                [PSCustomObject] @{ A = '1'; B = '2'; C = '3' }
+            ) | Export-Csv -Path $csvPath -NoTypeInformation
+
+            $result = Compare-List -Path $csvPath -WarningAction SilentlyContinue
+            $result | Should -BeNullOrEmpty
         }
 
-        BeforeEach {
-            $a = Get-Process | Where-Object ProcessName
-            $b = $a | Select-Object -First 8
-            $List = @()
-            for ( $i = 0; $i -lt $a.Count; $i++ ) {
-                $new = @{ A = $a[$i].ProcessName }
-                if ( $b[$i] ) { $new['B'] = $b[$i].ProcessName } else { $new['B'] = '' }
-                $List += [PSCustomObject] $new
-            }
-            $Path = 'TestDrive:/test_compare_list.csv' # "TestDrive:\test.csv" OR 'Temp:/test_compare_list.csv'
-            $List | Export-Csv -Path $Path
+        It -Name 'rejects a path that does not exist' -Test {
+            $missing = Join-Path -Path $TestDrive -ChildPath 'no-such-file.csv'
+            { Compare-List -Path $missing } | Should -Throw
+        }
+
+        It -Name 'rejects a non-CSV file extension' -Test {
+            $txtPath = Join-Path -Path $TestDrive -ChildPath 'notes.txt'
+            Set-Content -Path $txtPath -Value 'A,B'
+            { Compare-List -Path $txtPath } | Should -Throw
         }
     }
 }

--- a/Tests/Unit/Convert-SecureKey.tests.ps1
+++ b/Tests/Unit/Convert-SecureKey.tests.ps1
@@ -1,51 +1,109 @@
 BeforeDiscovery {
-    # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
-    # Import module
     if (-not (Get-Module -Name $env:BHProjectName)) {
         Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
     }
-    $Cmdlets = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
 }
 
-Describe -Name "Convert-SecureKey" -Fixture {
-    Context -Name "'create' parameter set" -Fixture {
-        It -Name "should not fail" -Test {
-            { Convert-SecureKey -DestinationPath $Path -Username 'user' -SecurePassword $SecurePW -PassThru } |
-            Should -Not -Throw
-        }
-        It -Name "creates an XML file" -Test {
-            Convert-SecureKey -DestinationPath $Path -Username 'user' -SecurePassword $SecurePW
-            ( Test-Path -Path $Path -PathType Leaf -Include "*.xml" ) | Should -BeTrue
-        }
-        It -Name "xml file contains PSCredential object" -Test {
-            Convert-SecureKey -DestinationPath $Path -Username 'user' -SecurePassword $SecurePW
-            $Creds = Import-Clixml -Path $Path
-            $Creds.GetType().Name | Should -Be 'PSCredential'
-        }
-        AfterEach {
-            Remove-Item -Path $Path
-        }
-    }
-
-    Context -Name "'retrieve' parameter set" -Fixture {
-        It -Name "should not fail" -Test {
-            { Convert-SecureKey -Path $Path } | Should -Not -Throw
-        }
-        It -Name "returns a PSCredential object" -Test {
-            (Convert-SecureKey -Path $Path).GetType().Name | Should -Be 'PSCredential'
-        }
-        BeforeAll {
-            Convert-SecureKey -DestinationPath $Path -Username 'user' -SecurePassword $SecurePW -PassThru
-        }
-    }
+Describe -Name 'Convert-SecureKey' -Fixture {
 
     BeforeAll {
-        New-Item -Path 'Temp:/test/' -ItemType Directory -Force
-        $Path = 'Temp:/test/secure_key.xml' # 'TestDrive:/test/test.csv # 'Temp:/test/secure_key.xml'
-        $SecurePW = ConvertTo-SecureString -String 'SuperPassword123' -AsPlainText -Force
+        $script:SecurePW = ConvertTo-SecureString -String 'SuperPassword123' -AsPlainText -Force
     }
 
-    AfterAll {
-        Remove-Item -Path (Split-Path -Path $Path) -Recurse -Force
+    Context -Name "'_create' parameter set" -Fixture {
+        BeforeEach {
+            $script:DestPath = Join-Path -Path $TestDrive -ChildPath ('cred-{0}.xml' -f ([System.Guid]::NewGuid().ToString('N')))
+        }
+
+        It -Name 'creates an XML file at -DestinationPath' -Test {
+            Convert-SecureKey -DestinationPath $script:DestPath -Username 'user' -SecurePassword $script:SecurePW
+            Test-Path -Path $script:DestPath -PathType Leaf | Should -BeTrue
+        }
+
+        It -Name 'serializes a PSCredential object that round-trips back' -Test {
+            Convert-SecureKey -DestinationPath $script:DestPath -Username 'alice' -SecurePassword $script:SecurePW
+            $cred = Import-Clixml -Path $script:DestPath
+            $cred | Should -BeOfType [System.Management.Automation.PSCredential]
+            $cred.UserName | Should -Be 'alice'
+        }
+
+        It -Name 'returns the PSCredential when -PassThru is supplied' -Test {
+            $cred = Convert-SecureKey -DestinationPath $script:DestPath -Username 'bob' -SecurePassword $script:SecurePW -PassThru
+            $cred | Should -BeOfType [System.Management.Automation.PSCredential]
+            $cred.UserName | Should -Be 'bob'
+        }
+
+        It -Name 'returns nothing when -PassThru is omitted' -Test {
+            $result = Convert-SecureKey -DestinationPath $script:DestPath -Username 'silent' -SecurePassword $script:SecurePW
+            $result | Should -BeNullOrEmpty
+        }
+
+        It -Name 'refuses to overwrite an existing file without -Force' -Test {
+            Convert-SecureKey -DestinationPath $script:DestPath -Username 'first' -SecurePassword $script:SecurePW
+            { Convert-SecureKey -DestinationPath $script:DestPath -Username 'second' -SecurePassword $script:SecurePW -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*already exists*'
+        }
+
+        It -Name 'overwrites an existing file when -Force is supplied' -Test {
+            Convert-SecureKey -DestinationPath $script:DestPath -Username 'first' -SecurePassword $script:SecurePW
+            Convert-SecureKey -DestinationPath $script:DestPath -Username 'second' -SecurePassword $script:SecurePW -Force
+            (Import-Clixml -Path $script:DestPath).UserName | Should -Be 'second'
+        }
+    }
+
+    Context -Name "'_create' parameter validation" -Fixture {
+        It -Name 'rejects a -DestinationPath with a non-.xml extension' -Test {
+            $bad = Join-Path -Path $TestDrive -ChildPath 'creds.txt'
+            { Convert-SecureKey -DestinationPath $bad -Username 'user' -SecurePassword $script:SecurePW } |
+                Should -Throw
+        }
+
+        It -Name 'rejects a -DestinationPath whose parent directory does not exist' -Test {
+            $bad = Join-Path -Path $TestDrive -ChildPath 'no-such-dir/creds.xml'
+            { Convert-SecureKey -DestinationPath $bad -Username 'user' -SecurePassword $script:SecurePW } |
+                Should -Throw
+        }
+
+        It -Name 'rejects an empty -Username' -Test {
+            $dest = Join-Path -Path $TestDrive -ChildPath 'empty-user.xml'
+            { Convert-SecureKey -DestinationPath $dest -Username '' -SecurePassword $script:SecurePW } |
+                Should -Throw
+        }
+    }
+
+    Context -Name "'_retrieve' parameter set" -Fixture {
+        BeforeAll {
+            $script:RetrievePath = Join-Path -Path $TestDrive -ChildPath 'retrieve.xml'
+            Convert-SecureKey -DestinationPath $script:RetrievePath -Username 'retriever' -SecurePassword $script:SecurePW
+        }
+
+        It -Name 'returns a PSCredential object for a valid file' -Test {
+            $cred = Convert-SecureKey -Path $script:RetrievePath
+            $cred | Should -BeOfType [System.Management.Automation.PSCredential]
+            $cred.UserName | Should -Be 'retriever'
+        }
+    }
+
+    Context -Name "'_retrieve' parameter validation" -Fixture {
+        It -Name 'rejects a -Path that does not exist' -Test {
+            $missing = Join-Path -Path $TestDrive -ChildPath 'no-such.xml'
+            { Convert-SecureKey -Path $missing } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path that is not an .xml file' -Test {
+            $nonXml = Join-Path -Path $TestDrive -ChildPath 'creds.txt'
+            Set-Content -Path $nonXml -Value 'not xml'
+            { Convert-SecureKey -Path $nonXml } | Should -Throw
+        }
+    }
+
+    Context -Name 'parameter set conflict' -Fixture {
+        It -Name 'rejects supplying both -Path and -Username/-DestinationPath' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'conflict.xml'
+            Convert-SecureKey -DestinationPath $src -Username 'u' -SecurePassword $script:SecurePW
+            $dest = Join-Path -Path $TestDrive -ChildPath 'conflict2.xml'
+            { Convert-SecureKey -Path $src -Username 'u' -SecurePassword $script:SecurePW -DestinationPath $dest } |
+                Should -Throw
+        }
     }
 }

--- a/Tests/Unit/Convert-TimeZone.tests.ps1
+++ b/Tests/Unit/Convert-TimeZone.tests.ps1
@@ -1,49 +1,105 @@
 BeforeDiscovery {
-    # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
-    # Import module
     if (-not (Get-Module -Name $env:BHProjectName)) {
         Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
     }
-    $Cmdlets = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
 }
 
-Describe -Name "Convert-TimeZone" -Fixture {
-    Context -Name "converts single time" -Fixture {
-        It -Name "converts Pacific to Eastern time" -Test {
-            $convert = Convert-TimeZone -Time $time -SourceTimeZone Pacific -TargetTimeZone Eastern
-            $convert.Eastern | Should -Be $time.AddHours(3)
+Describe -Name 'Convert-TimeZone' -Fixture {
+
+    BeforeAll {
+        $script:Time = Get-Date -Date '2011-10-05 3:00pm'
+    }
+
+    Context -Name 'converts single time' -Fixture {
+        It -Name 'converts Pacific to Eastern time' -Test {
+            $convert = Convert-TimeZone -Time $script:Time -SourceTimeZone Pacific -TargetTimeZone Eastern
+            $convert.Eastern | Should -Be $script:Time.AddHours(3)
         }
 
-        It -Name "converts Eastern to UTC time" -Test {
-            $convert = Convert-TimeZone -Time $time -SourceTimeZone Eastern -TargetTimeZone UTC
+        It -Name 'converts Eastern to UTC time' -Test {
+            $convert = Convert-TimeZone -Time $script:Time -SourceTimeZone Eastern -TargetTimeZone UTC
             $convert.UTC | Should -Be (Get-Date -Date '10/5/2011 7:00:00 PM')
         }
 
-        It -Name "converts UTC to Pacific time" -Test {
-            $convert = Convert-TimeZone -Time $time -SourceTimeZone UTC -TargetTimeZone Pacific
+        It -Name 'converts UTC to Pacific time' -Test {
+            $convert = Convert-TimeZone -Time $script:Time -SourceTimeZone UTC -TargetTimeZone Pacific
             $convert.Pacific | Should -Be (Get-Date -Date '10/5/2011 8:00:00 AM')
+        }
+
+        It -Name 'returns the same instant when Source and Target are equal' -Test {
+            $convert = Convert-TimeZone -Time $script:Time -SourceTimeZone Eastern -TargetTimeZone Eastern
+            $convert.Eastern | Should -Be $script:Time
         }
     }
 
-    Context -Name "converts multiple times" -Fixture {
-        It -Name "converts times through pipeline" -Test {
-            $convert = $time, $time2, $time3 | Convert-TimeZone -SourceTimeZone Pacific -TargetTimeZone Mountain
+    Context -Name 'converts multiple times' -Fixture {
+        BeforeAll {
+            $script:Time2 = Get-Date -Date '2050-01-15 9:00am'
+            $script:Time3 = Get-Date -Date '2050-06-01 4:20pm'
+        }
+
+        It -Name 'converts times through pipeline' -Test {
+            $convert = $script:Time, $script:Time2, $script:Time3 |
+            Convert-TimeZone -SourceTimeZone Pacific -TargetTimeZone Mountain
             $convert | Should -HaveCount 3
         }
 
-        It -Name "converts multiple times in an array" -Test {
-            $array = @($time, $time2, $time3)
+        It -Name 'converts multiple times in an array' -Test {
+            $array = @($script:Time, $script:Time2, $script:Time3)
             $convert = Convert-TimeZone -Time $array -SourceTimeZone Pacific -TargetTimeZone Mountain
             $convert | Should -HaveCount 3
         }
+    }
 
-        BeforeAll {
-            $time2 = Get-Date
-            $time3 = Get-Date -Date "2050-06-01 4:20pm"
+    Context -Name 'output shape' -Fixture {
+        It -Name 'returns a PSCustomObject with Source, UTC, and Target properties' -Test {
+            $convert = Convert-TimeZone -Time $script:Time -SourceTimeZone Pacific -TargetTimeZone Eastern
+            $convert | Should -BeOfType [System.Management.Automation.PSCustomObject]
+            $convert.PSObject.Properties.Name | Should -Contain 'Pacific'
+            $convert.PSObject.Properties.Name | Should -Contain 'UTC'
+            $convert.PSObject.Properties.Name | Should -Contain 'Eastern'
         }
     }
 
-    BeforeAll {
-        $time = Get-Date -Date "2011-10-05 3:00pm"
+    Context -Name 'DST awareness' -Fixture {
+        # The Pacific time zone is UTC-7 (PDT) in summer and UTC-8 (PST) in winter.
+        # The function uses Get-TimeZone + TimeZoneInfo, so the offset must adjust with the date.
+        It -Name 'applies PDT offset (UTC-7) for a summer Pacific timestamp' -Test {
+            $summer = Get-Date -Date '2024-07-15 12:00:00'
+            $convert = Convert-TimeZone -Time $summer -SourceTimeZone Pacific -TargetTimeZone UTC
+            $convert.UTC | Should -Be (Get-Date -Date '2024-07-15 19:00:00')
+        }
+
+        It -Name 'applies PST offset (UTC-8) for a winter Pacific timestamp' -Test {
+            $winter = Get-Date -Date '2024-01-15 12:00:00'
+            $convert = Convert-TimeZone -Time $winter -SourceTimeZone Pacific -TargetTimeZone UTC
+            $convert.UTC | Should -Be (Get-Date -Date '2024-01-15 20:00:00')
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an unknown -SourceTimeZone value' -Test {
+            { Convert-TimeZone -Time $script:Time -SourceTimeZone 'Atlantis' -TargetTimeZone UTC } |
+            Should -Throw
+        }
+
+        It -Name 'rejects an unknown -TargetTimeZone value' -Test {
+            { Convert-TimeZone -Time $script:Time -SourceTimeZone UTC -TargetTimeZone 'Mars' } |
+            Should -Throw
+        }
+
+        It -Name 'rejects an unparseable -Time string' -Test {
+            { Convert-TimeZone -Time 'not a date' -TargetTimeZone UTC } | Should -Throw
+        }
+    }
+
+    Context -Name 'default behavior' -Fixture {
+        It -Name 'uses current time when -Time is omitted' -Test {
+            $before = Get-Date
+            $convert = Convert-TimeZone -SourceTimeZone Local -TargetTimeZone UTC
+            $after = Get-Date
+            $convert.Local | Should -BeGreaterOrEqual $before.AddSeconds(-1)
+            $convert.Local | Should -BeLessOrEqual $after.AddSeconds(1)
+        }
     }
 }

--- a/Tests/Unit/Find-ServerPendingReboot.tests.ps1
+++ b/Tests/Unit/Find-ServerPendingReboot.tests.ps1
@@ -1,18 +1,28 @@
 BeforeDiscovery {
-    # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
-    # Import module
     if (-not (Get-Module -Name $env:BHProjectName)) {
         Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
     }
-    $Cmdlets = Get-Command -Module $env:BHProjectName -CommandType 'Cmdlet', 'Function' -ErrorAction 'Stop'
 }
 
-Describe -Name "Find-ServerPendingReboot" -Fixture {
-    It -Name "should not throw" -Skip:(-not $IsWindows) -Test {
-        { Find-ServerPendingReboot } | Should -Not -Throw
+Describe -Name 'Find-ServerPendingReboot' -Fixture {
+
+    Context -Name 'platform guard' -Fixture {
+        It -Name 'errors when not running on Windows' -Skip:$IsWindows -Test {
+            { Find-ServerPendingReboot -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*requires Windows*'
+        }
     }
 
-    It -Name "should return boolean" -Skip:(-not $IsWindows) -Test {
-        { Find-ServerPendingReboot } | Should -Be ($true -or $false)
+    Context -Name 'normal usage' -Fixture {
+        It -Name 'does not throw on Windows' -Skip:(-not $IsWindows) -Test {
+            { Find-ServerPendingReboot } | Should -Not -Throw
+        }
+
+        It -Name 'returns one object per ComputerName with RebootIsPending boolean' -Skip:(-not $IsWindows) -Test {
+            $result = Find-ServerPendingReboot
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName    | Should -Be $env:COMPUTERNAME
+            $result.RebootIsPending | Should -BeOfType [System.Boolean]
+        }
     }
 }

--- a/Tests/Unit/New-RandomString.tests.ps1
+++ b/Tests/Unit/New-RandomString.tests.ps1
@@ -1,0 +1,88 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'New-RandomString' -Fixture {
+
+    Context -Name 'default behavior' -Fixture {
+        It -Name 'returns a string of the default length (8)' -Test {
+            $s = New-RandomString
+            $s | Should -BeOfType [System.String]
+            $s.Length | Should -Be 8
+        }
+
+        It -Name 'returns a string of the requested -Length' -Test {
+            (New-RandomString -Length 20).Length | Should -Be 20
+        }
+
+        It -Name 'returns a different string on each invocation (sanity check)' -Test {
+            $a = New-RandomString -Length 32
+            $b = New-RandomString -Length 32
+            $a | Should -Not -Be $b
+        }
+
+        It -Name 'is exposed under the Get-RandomString alias' -Test {
+            (Get-Command -Name Get-RandomString -ErrorAction Stop).ResolvedCommand.Name |
+            Should -Be 'New-RandomString'
+        }
+    }
+
+    Context -Name 'character-set exclusions' -Fixture {
+        # Use generous length so that if a set were not actually excluded, at least one of those
+        # characters would almost certainly appear (probability of false pass is negligible).
+        BeforeAll {
+            $script:Len = 200
+        }
+
+        It -Name '-ExcludeNumber produces a string with no digits' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeNumber
+            $s | Should -Not -Match '\d'
+        }
+
+        # Use -CMatch / -CNotMatch (case-sensitive) — default -Match is case-insensitive,
+        # so [a-z] would also match A-Z and mask exclusion failures.
+        It -Name '-ExcludeLowercase produces a string with no lowercase letters' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeLowercase
+            $s | Should -Not -CMatch '[a-z]'
+        }
+
+        It -Name '-ExcludeUppercase produces a string with no uppercase letters' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeUppercase
+            $s | Should -Not -CMatch '[A-Z]'
+        }
+
+        It -Name '-ExcludeSpecial produces a string with only alphanumerics' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeSpecial
+            $s | Should -CMatch '^[A-Za-z0-9]+$'
+        }
+
+        It -Name '-ExcludeCharacter removes the requested character from the output' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeCharacter 'a'
+            $s | Should -Not -CMatch 'a'
+        }
+
+        It -Name 'composes multiple exclusion flags' -Test {
+            $s = New-RandomString -Length $script:Len -ExcludeNumber -ExcludeSpecial
+            $s | Should -CMatch '^[A-Za-z]+$'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'errors when every character set is excluded' -Test {
+            { New-RandomString -ExcludeNumber -ExcludeLowercase -ExcludeUppercase -ExcludeSpecial -ErrorAction Stop } |
+            Should -Throw -ExpectedMessage '*at least one character set*'
+        }
+    }
+
+    Context -Name 'edge-case lengths' -Fixture {
+        It -Name 'returns a single character when -Length is 1' -Test {
+            (New-RandomString -Length 1).Length | Should -Be 1
+        }
+
+        It -Name 'handles large lengths (1024 chars)' -Test {
+            (New-RandomString -Length 1024).Length | Should -Be 1024
+        }
+    }
+}

--- a/Tests/Unit/Read-EncryptedFile.tests.ps1
+++ b/Tests/Unit/Read-EncryptedFile.tests.ps1
@@ -1,0 +1,76 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Read-EncryptedFile' -Fixture {
+
+    BeforeAll {
+        function New-EncryptedFixture {
+            param(
+                [Parameter(Mandatory)] [string] $Path,
+                [Parameter(Mandatory)] [string] $Content,
+                [string] $Key
+            )
+            Write-EncryptedFile -Content $Content -Path $Path -Key $Key | Out-Null
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a Path that does not exist' -Test {
+            $missing = Join-Path -Path $TestDrive -ChildPath 'no-such.enc'
+            { Read-EncryptedFile -Path $missing -Key 'k' } | Should -Throw
+        }
+
+        It -Name 'rejects a Path that is a directory rather than a file' -Test {
+            $dir = Join-Path -Path $TestDrive -ChildPath 'dir-not-file'
+            New-Item -Path $dir -ItemType Directory | Out-Null
+            { Read-EncryptedFile -Path $dir -Key 'k' } | Should -Throw
+        }
+
+        It -Name 'rejects supplying both -Key and -KeyBytes (parameter set conflict)' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'both.enc'
+            New-EncryptedFixture -Path $src -Content 'data' -Key 'k'
+            { Read-EncryptedFile -Path $src -Key 'k' -KeyBytes ([byte[]] @(1, 2, 3)) } |
+                Should -Throw
+        }
+    }
+
+    Context -Name 'happy path' -Fixture {
+        It -Name 'decrypts a file with the correct string key' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'hp1.enc'
+            New-EncryptedFixture -Path $src -Content 'plaintext' -Key 'secret'
+            (Read-EncryptedFile -Path $src -Key 'secret') | Should -Be 'plaintext'
+        }
+
+        It -Name 'decrypts a file with a byte-array key' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'hp2.enc'
+            $keyBytes = [System.Byte[]] '0123456789ABCDEF0123456789ABCDEF'.ToCharArray()
+            Write-EncryptedFile -Content 'byte-decrypt' -Path $src -KeyBytes $keyBytes | Out-Null
+            (Read-EncryptedFile -Path $src -KeyBytes $keyBytes) | Should -Be 'byte-decrypt'
+        }
+
+        It -Name 'preserves multi-line content across the round-trip' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'hp3.enc'
+            'a', 'b', 'c' | Write-EncryptedFile -Path $src -Key 'k' | Out-Null
+            (Read-EncryptedFile -Path $src -Key 'k') |
+                Should -Be ('a{0}b{0}c' -f [Environment]::NewLine)
+        }
+    }
+
+    Context -Name 'wrong-key behavior' -Fixture {
+        # Decrypting with the wrong key may either throw (CryptographicException padding error)
+        # or silently return garbage bytes depending on whether the random plaintext happens to
+        # produce valid PKCS7 padding. Both outcomes are acceptable; what matters is that the
+        # original plaintext is NOT recovered.
+        It -Name 'never returns the original plaintext when given a different key' -Test {
+            $src = Join-Path -Path $TestDrive -ChildPath 'wrong-key.enc'
+            New-EncryptedFixture -Path $src -Content 'do-not-leak' -Key 'right'
+
+            $result = $null
+            try { $result = Read-EncryptedFile -Path $src -Key 'wrong' } catch { $result = $null }
+            $result | Should -Not -Be 'do-not-leak'
+        }
+    }
+}

--- a/Tests/Unit/Set-GitHubBranchProtection.tests.ps1
+++ b/Tests/Unit/Set-GitHubBranchProtection.tests.ps1
@@ -7,25 +7,171 @@ BeforeDiscovery {
 Describe -Name 'Set-GitHubBranchProtection' -Fixture {
 
     Context -Name 'parameter validation' -Fixture {
-        It -Name 'has a mandatory Owner parameter' -Test {
+        It -Name 'declares Owner as mandatory' -Test {
             (Get-Command -Name Set-GitHubBranchProtection).Parameters['Owner'].Attributes.Mandatory |
                 Should -Contain $true
         }
 
-        It -Name 'has a mandatory Repository parameter that accepts pipeline input' -Test {
+        It -Name 'declares Repository as mandatory and accepts pipeline input' -Test {
             $param = (Get-Command -Name Set-GitHubBranchProtection).Parameters['Repository']
-            $param.Attributes.Mandatory | Should -Contain $true
+            $param.Attributes.Mandatory         | Should -Contain $true
             $param.Attributes.ValueFromPipeline | Should -Contain $true
         }
 
-        It -Name 'rejects ApprovalCount values outside 0-6' -Test {
-            { Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -ApprovalCount 7 -WhatIf } |
-                Should -Throw
-        }
-
-        It -Name 'supports ShouldProcess' -Test {
+        It -Name 'supports ShouldProcess (-WhatIf is available)' -Test {
             (Get-Command -Name Set-GitHubBranchProtection).Parameters.ContainsKey('WhatIf') |
                 Should -BeTrue
+        }
+
+        It -Name 'rejects an empty Repository value' -Test {
+            { Set-GitHubBranchProtection -Owner 'octocat' -Repository '' -WhatIf } | Should -Throw
+        }
+    }
+
+    Context -Name 'pre-flight: gh CLI missing' -Fixture {
+        BeforeAll {
+            Mock -CommandName Get-Command `
+                -ParameterFilter { $Name -eq 'gh' } `
+                -MockWith { } `
+                -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'errors when the gh CLI is not on PATH' -Test {
+            { Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -WhatIf -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*gh CLI not found*'
+        }
+    }
+
+    Context -Name 'execution paths' -Fixture {
+
+        BeforeAll {
+            $script:MatchingExistingJson = @'
+{
+    "required_signatures": { "enabled": true },
+    "enforce_admins": { "enabled": true },
+    "required_linear_history": { "enabled": true },
+    "allow_force_pushes": { "enabled": false },
+    "allow_deletions": { "enabled": false },
+    "required_conversation_resolution": { "enabled": true },
+    "required_status_checks": { "strict": true, "contexts": [] },
+    "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false
+    }
+}
+'@
+
+            $script:ConflictingExistingJson = @'
+{
+    "required_signatures": { "enabled": false },
+    "enforce_admins": { "enabled": true },
+    "required_linear_history": { "enabled": false },
+    "allow_force_pushes": { "enabled": true },
+    "allow_deletions": { "enabled": false },
+    "required_conversation_resolution": { "enabled": true },
+    "required_status_checks": { "strict": true, "contexts": [] },
+    "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false
+    }
+}
+'@
+        }
+
+        BeforeEach {
+            $script:ApiGetExitCode = 0
+            $script:ApiGetResponse = $script:MatchingExistingJson
+
+            Mock -CommandName gh -ModuleName $env:BHProjectName -MockWith {
+                if ($args -contains 'auth') {
+                    $global:LASTEXITCODE = 0
+                    return 'Logged in to github.com'
+                }
+                if ($args -contains 'repo' -and $args -contains 'view') {
+                    $global:LASTEXITCODE = 0
+                    return '{"defaultBranchRef":{"name":"main"}}'
+                }
+                if ($args -contains 'api') {
+                    if ($args -contains '-X' -and $args -contains 'PUT') {
+                        $global:LASTEXITCODE = 0
+                        return '{"url":"applied"}'
+                    }
+                    $global:LASTEXITCODE = $script:ApiGetExitCode
+                    return $script:ApiGetResponse
+                }
+                $global:LASTEXITCODE = 0
+                return ''
+            }
+        }
+
+        It -Name 'returns AlreadyProtected and skips PUT when existing rule matches desired policy' -Test {
+            $result = Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -Confirm:$false
+
+            $result.Result     | Should -Be 'AlreadyProtected'
+            $result.Repository | Should -Be 'octocat/demo'
+            $result.Branch     | Should -Be 'main'
+
+            Should -Invoke -CommandName gh -ModuleName $env:BHProjectName `
+                -ParameterFilter { $args -contains '-X' -and $args -contains 'PUT' } -Times 0 -Exactly
+        }
+
+        It -Name 'returns Conflict and skips PUT when existing rule differs and -Force is absent' -Test {
+            $script:ApiGetResponse = $script:ConflictingExistingJson
+
+            $result = Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -Confirm:$false `
+                -WarningAction SilentlyContinue
+
+            $result.Result  | Should -Be 'Conflict'
+            $result.Message | Should -BeLike '*Existing rule differs*'
+
+            Should -Invoke -CommandName gh -ModuleName $env:BHProjectName `
+                -ParameterFilter { $args -contains '-X' -and $args -contains 'PUT' } -Times 0 -Exactly
+        }
+
+        It -Name 'returns Protected and issues PUT when existing rule differs and -Force is set' -Test {
+            $script:ApiGetResponse = $script:ConflictingExistingJson
+
+            $result = Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -Force -Confirm:$false
+
+            $result.Result | Should -Be 'Protected'
+
+            Should -Invoke -CommandName gh -ModuleName $env:BHProjectName `
+                -ParameterFilter { $args -contains '-X' -and $args -contains 'PUT' } -Times 1 -Exactly
+        }
+
+        It -Name 'returns Protected and issues PUT when no existing rule is found' -Test {
+            $script:ApiGetExitCode = 1
+            $script:ApiGetResponse = 'HTTP 404: Branch not protected'
+
+            $result = Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -Confirm:$false
+
+            $result.Result | Should -Be 'Protected'
+
+            Should -Invoke -CommandName gh -ModuleName $env:BHProjectName `
+                -ParameterFilter { $args -contains '-X' -and $args -contains 'PUT' } -Times 1 -Exactly
+        }
+
+        It -Name '-WhatIf returns Skipped and issues no PUT' -Test {
+            $script:ApiGetExitCode = 1
+            $script:ApiGetResponse = 'HTTP 404: Branch not protected'
+
+            $result = Set-GitHubBranchProtection -Owner 'octocat' -Repository 'demo' -WhatIf
+
+            $result.Result | Should -Be 'Skipped'
+
+            Should -Invoke -CommandName gh -ModuleName $env:BHProjectName `
+                -ParameterFilter { $args -contains '-X' -and $args -contains 'PUT' } -Times 0 -Exactly
+        }
+
+        It -Name 'accepts multiple repositories via the pipeline' -Test {
+            $results = 'demo-a', 'demo-b' | Set-GitHubBranchProtection -Owner 'octocat' -Confirm:$false
+
+            $results | Should -HaveCount 2
+            $results.Repository | Should -Be @('octocat/demo-a', 'octocat/demo-b')
         }
     }
 }

--- a/Tests/Unit/Write-EncryptedFile.tests.ps1
+++ b/Tests/Unit/Write-EncryptedFile.tests.ps1
@@ -1,0 +1,88 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Write-EncryptedFile' -Fixture {
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a Path whose parent directory does not exist' -Test {
+            $bad = Join-Path -Path $TestDrive -ChildPath 'no-such-dir/out.enc'
+            { Write-EncryptedFile -Content 'data' -Path $bad -Key 'k' } | Should -Throw
+        }
+
+        It -Name 'rejects supplying both -Key and -KeyBytes (parameter set conflict)' -Test {
+            $dest = Join-Path -Path $TestDrive -ChildPath 'both.enc'
+            { Write-EncryptedFile -Content 'data' -Path $dest -Key 'k' -KeyBytes ([byte[]] @(1, 2, 3)) } |
+                Should -Throw
+        }
+    }
+
+    Context -Name 'happy path' -Fixture {
+        BeforeEach {
+            $script:DestPath = Join-Path -Path $TestDrive -ChildPath ('enc-{0}.bin' -f ([System.Guid]::NewGuid().ToString('N')))
+        }
+
+        It -Name 'creates the destination file and returns a FileInfo for it' -Test {
+            $result = Write-EncryptedFile -Content 'hello' -Path $script:DestPath -Key 'Password123'
+            Test-Path -Path $script:DestPath -PathType Leaf | Should -BeTrue
+            $result | Should -BeOfType [System.IO.FileInfo]
+            $result.FullName | Should -Be $script:DestPath
+        }
+
+        It -Name 'writes encrypted bytes (output differs from plaintext)' -Test {
+            $plaintext = 'attack at dawn'
+            Write-EncryptedFile -Content $plaintext -Path $script:DestPath -Key 'k'
+            $bytes = [System.IO.File]::ReadAllBytes($script:DestPath)
+            $bytes.Length | Should -BeGreaterThan 0
+            ([System.Text.Encoding]::UTF8.GetString($bytes)) | Should -Not -Be $plaintext
+        }
+
+        It -Name 'round-trips through Read-EncryptedFile with a string key' -Test {
+            Write-EncryptedFile -Content 'round-trip me' -Path $script:DestPath -Key 'shared'
+            (Read-EncryptedFile -Path $script:DestPath -Key 'shared') | Should -Be 'round-trip me'
+        }
+
+        It -Name 'round-trips through Read-EncryptedFile with a byte-array key' -Test {
+            $keyBytes = [System.Byte[]] 'abcdefghijklmnopqrstuvwxyz012345'.ToCharArray()
+            Write-EncryptedFile -Content 'byte-key' -Path $script:DestPath -KeyBytes $keyBytes
+            (Read-EncryptedFile -Path $script:DestPath -KeyBytes $keyBytes) | Should -Be 'byte-key'
+        }
+
+        It -Name 'pads short keys so a 5-char key round-trips' -Test {
+            Write-EncryptedFile -Content 'short-key' -Path $script:DestPath -Key 'short'
+            (Read-EncryptedFile -Path $script:DestPath -Key 'short') | Should -Be 'short-key'
+        }
+
+        It -Name 'truncates long keys so a 64-char key round-trips' -Test {
+            $longKey = 'a' * 64
+            Write-EncryptedFile -Content 'long-key' -Path $script:DestPath -Key $longKey
+            (Read-EncryptedFile -Path $script:DestPath -Key $longKey) | Should -Be 'long-key'
+        }
+
+        It -Name 'round-trips multi-line content via pipeline' -Test {
+            'line one', 'line two', 'line three' |
+                Write-EncryptedFile -Path $script:DestPath -Key 'multi'
+            $decrypted = Read-EncryptedFile -Path $script:DestPath -Key 'multi'
+            $decrypted | Should -Be ('line one{0}line two{0}line three' -f [Environment]::NewLine)
+        }
+    }
+
+    Context -Name 'ShouldProcess behavior' -Fixture {
+        It -Name '-WhatIf does not create the destination file' -Test {
+            $dest = Join-Path -Path $TestDrive -ChildPath 'whatif.enc'
+            Write-EncryptedFile -Content 'data' -Path $dest -Key 'k' -WhatIf
+            Test-Path -Path $dest | Should -BeFalse
+        }
+    }
+
+    Context -Name 'overwrite semantics' -Fixture {
+        It -Name 'overwrites an existing file at Path with new ciphertext' -Test {
+            $dest = Join-Path -Path $TestDrive -ChildPath 'overwrite.enc'
+            Write-EncryptedFile -Content 'first' -Path $dest -Key 'k'
+            Write-EncryptedFile -Content 'second' -Path $dest -Key 'k'
+            (Read-EncryptedFile -Path $dest -Key 'k') | Should -Be 'second'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Expands Pester coverage in two slices from issue #109:

**Group C — thin-test upgrades** (initial commit, +13 tests)
- `Compare-List` — deterministic fixtures replacing flaky `Get-Process` data; adds duplicate, single-item, empty-array, malformed-CSV cases
- `Find-ServerPendingReboot` — Windows-only guard via `-Skip:$IsWindows`; cross-platform throw assertion + Windows shape assertions
- `Set-GitHubBranchProtection` — replaces metadata-only tests with `gh` CLI mocking (auth / repo-view / api dispatch); covers conflict-detection, idempotent skip, `-Force` override, pre-flight failures

**D1 — Encryption / sensitive-data** (second commit, +47 tests)
- `Write-EncryptedFile` *(new)* — round-trip with `Read-EncryptedFile`, string + byte-array keys, key padding/truncation, multi-line pipeline input, `-WhatIf` no-write, parameter-set conflict
- `Read-EncryptedFile` *(new)* — round-trip, byte-array key, wrong-key never leaks plaintext, path/dir validation
- `New-RandomString` *(new)* — per-set exclusion (case-sensitive regex), `-ExcludeCharacter`, all-sets-excluded error, edge lengths
- `Convert-SecureKey` *(expanded)* — overwrite-without-Force error, `-Force` overwrite, `-PassThru` shape, parameter-set conflict
- `Convert-TimeZone` *(expanded)* — DST-aware Pacific⇄UTC offsets (PDT summer / PST winter), output-shape, equal-zone identity, unknown-zone/unparseable-time rejection

Total: **+60 effective tests**; suite is **728 passed / 2 skipped** locally (Windows-guarded tests skip on macOS/Linux).

Closes none yet — both groups partially close #109.

## Test plan

- [x] `./Build/build.ps1 -TaskList Test, Cleanup` passes locally on macOS (PS 7.6.2)
- [ ] CI passes on `ubuntu-latest` (GitHub Actions)
- [ ] Reviewer confirms the `gh` mocking pattern in `Set-GitHubBranchProtection.tests.ps1` is acceptable as the template for future D2 network/API tests