### PR TITLE
test(SecurityTools): Group B + D7 coverage, Get-UncPath fixes, manifest cleanup (refs #109)

### DIFF
--- a/Public/Get-UncPath.ps1
+++ b/Public/Get-UncPath.ps1
@@ -29,7 +29,7 @@ function Get-UncPath {
     [CmdletBinding()]
     [OutputType([System.String])]
     Param(
-        [Parameter(Mandatory, HelpMessage = 'Local path')]
+        [Parameter(Mandatory, ValueFromPipeline, HelpMessage = 'Local path')]
         [ValidatePattern("[A-Z]:\\.+")]
         [System.String] $Path,
 
@@ -49,8 +49,8 @@ function Get-UncPath {
 
         if ( $Path.Substring(0.2) -match '[A-Z]:' ) {
             if ( $Unix ) {
-                $Path = $Path.Replace('\', '/')
-                $UncPath = '//' + $ComputerName + '/' + $Path.Replace(':', '$')
+                $unixPath = $Path.Replace('\', '/')
+                $UncPath = '//' + $ComputerName + '/' + $unixPath.Replace(':', '$')
             }
             else {
                 $UncPath = '\\' + $ComputerName + '\' + $Path.Replace(':', '$')

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -126,7 +126,6 @@
         'Get-LatestPowerShell'
         'Get-LoggedOnUser'
         'Get-MsiInfo'
-        'Get-Object'
         'Get-PatchTuesday'
         'Get-PublicIP'
         'Get-QRCode'

--- a/Tests/Unit/Get-CVSSv3BaseScore.tests.ps1
+++ b/Tests/Unit/Get-CVSSv3BaseScore.tests.ps1
@@ -40,4 +40,49 @@ Describe -Name 'Get-CVSSv3BaseScore' -Fixture {
             { Get-CVSSv3BaseScore -CVE 'INVALID-ID' } | Should -Throw
         }
     }
+
+    Context -Name 'malformed / non-matching response' -Fixture {
+        # Function does NOT throw when the regex finds no match. It catches the resulting
+        # null-property access and emits a warning instead, returning no pipeline output.
+        BeforeAll {
+            Mock -CommandName Invoke-WebRequest -MockWith {
+                [PSCustomObject] @{ Content = '<html><body>no score here</body></html>' }
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'emits a "No CVSS v3 score found" warning for unmatched content' -Test {
+            $warning = $null
+            Get-CVSSv3BaseScore -CVE 'CVE-2020-9999' -WarningVariable warning -WarningAction SilentlyContinue
+            $warning | Should -Not -BeNullOrEmpty
+            $warning -join ' ' | Should -BeLike '*No CVSS v3 score found*CVE-2020-9999*'
+        }
+
+        It -Name 'produces no pipeline output when the score cannot be parsed' -Test {
+            $result = Get-CVSSv3BaseScore -CVE 'CVE-2020-9999' -WarningAction SilentlyContinue
+            $result | Should -BeNullOrEmpty
+        }
+
+        It -Name 'does not throw even when the response is empty' -Test {
+            Mock -CommandName Invoke-WebRequest -MockWith {
+                [PSCustomObject] @{ Content = '' }
+            } -ModuleName $env:BHProjectName
+            { Get-CVSSv3BaseScore -CVE 'CVE-2020-9999' -WarningAction SilentlyContinue } |
+            Should -Not -Throw
+        }
+    }
+
+    Context -Name 'transport failure' -Fixture {
+        # When Invoke-WebRequest itself fails (network down, 5xx with -ErrorAction Stop default),
+        # the function does not catch it — the error propagates to the caller.
+        BeforeAll {
+            Mock -CommandName Invoke-WebRequest -MockWith {
+                throw [System.Net.WebException]::new('upstream unavailable')
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'propagates web request exceptions to the caller' -Test {
+            { Get-CVSSv3BaseScore -CVE 'CVE-2020-2659' } |
+            Should -Throw -ExpectedMessage '*upstream unavailable*'
+        }
+    }
 }

--- a/Tests/Unit/Get-CountryCode.tests.ps1
+++ b/Tests/Unit/Get-CountryCode.tests.ps1
@@ -1,0 +1,83 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-CountryCode' -Fixture {
+
+    BeforeAll {
+        # Minimal CSV mirroring the ISO-3166 columns the function reads.
+        $script:MockCsv = @'
+English short name,Alpha-2 code,Alpha-3 code,Numeric
+American Samoa,AS,ASM,016
+United States,US,USA,840
+United Kingdom,GB,GBR,826
+Germany,DE,DEU,276
+'@
+        $script:MockData = $script:MockCsv | ConvertFrom-Csv
+
+        Mock -CommandName Invoke-RestMethod -MockWith { $script:MockCsv } -ModuleName $env:BHProjectName
+    }
+
+    BeforeEach {
+        # Force a fresh fetch each test by clearing the cached global the function maintains.
+        Remove-Variable -Name 'CountryCodes' -Scope Global -ErrorAction Ignore
+    }
+
+    Context -Name 'lookup by Alpha-2 code' -Fixture {
+        It -Name 'returns the matching country row' -Test {
+            $result = Get-CountryCode -Code 'US'
+            $result.'English short name' | Should -Be 'United States'
+            $result.'Alpha-3 code'       | Should -Be 'USA'
+        }
+    }
+
+    Context -Name 'lookup by Alpha-3 code' -Fixture {
+        It -Name 'returns the matching country row' -Test {
+            $result = Get-CountryCode -Code 'DEU'
+            $result.'English short name' | Should -Be 'Germany'
+            $result.'Alpha-2 code'       | Should -Be 'DE'
+        }
+    }
+
+    Context -Name 'lookup by country name' -Fixture {
+        It -Name 'returns rows matching a substring of the English name' -Test {
+            $result = Get-CountryCode -Country 'United'
+            $result.Count | Should -BeGreaterOrEqual 2
+            ($result.'Alpha-2 code') | Should -Contain 'US'
+            ($result.'Alpha-2 code') | Should -Contain 'GB'
+        }
+    }
+
+    Context -Name 'caching' -Fixture {
+        It -Name 'fetches the catalog only once across multiple lookups' -Test {
+            Get-CountryCode -Code 'US' | Out-Null
+            Get-CountryCode -Code 'DE' | Out-Null
+            Get-CountryCode -Code 'GB' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 1 -Exactly
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a 1-letter Code' -Test {
+            { Get-CountryCode -Code 'U' } | Should -Throw
+        }
+
+        It -Name 'rejects a 4-letter Code' -Test {
+            { Get-CountryCode -Code 'USAA' } | Should -Throw
+        }
+
+        It -Name 'rejects a Code containing digits' -Test {
+            { Get-CountryCode -Code 'U5' } | Should -Throw
+        }
+
+        It -Name 'rejects -Code and -Country supplied together (parameter set conflict)' -Test {
+            { Get-CountryCode -Code 'US' -Country 'United States' } | Should -Throw
+        }
+    }
+
+    AfterAll {
+        Remove-Variable -Name 'CountryCodes' -Scope Global -ErrorAction Ignore
+    }
+}

--- a/Tests/Unit/Get-EPSS.tests.ps1
+++ b/Tests/Unit/Get-EPSS.tests.ps1
@@ -64,4 +64,53 @@ Describe -Name 'Get-EPSS' -Fixture {
             { Get-EPSS -CVE 'NOT-A-CVE' } | Should -Throw
         }
     }
+
+    Context -Name 'multiple CVEs as array argument (comma-joined)' -Fixture {
+        # When -CVE receives an array directly (vs piped), the function comma-joins them
+        # into a single request rather than iterating.
+        It -Name 'comma-joins multiple CVE values into a single request URI' -Test {
+            Get-EPSS -CVE 'CVE-2022-27225', 'CVE-2021-44228'
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $Uri -like '*cve=CVE-2022-27225,CVE-2021-44228*' }
+        }
+    }
+
+    Context -Name 'API failure' -Fixture {
+        # Invoke-RestMethod errors are not caught by the function — they propagate.
+        BeforeAll {
+            Mock -CommandName Invoke-RestMethod -MockWith {
+                throw [System.Net.WebException]::new('rate limit exceeded (429)')
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'propagates rate-limit / transport errors to the caller' -Test {
+            { Get-EPSS -CVE 'CVE-2022-27225' } |
+                Should -Throw -ExpectedMessage '*rate limit*'
+        }
+
+        It -Name 'propagates errors when no CVE is supplied (bulk request)' -Test {
+            { Get-EPSS } | Should -Throw -ExpectedMessage '*rate limit*'
+        }
+    }
+
+    Context -Name 'non-success API response' -Fixture {
+        # The function returns whatever Invoke-RestMethod hands back. If the API returns an
+        # error envelope (status != OK) we should still surface it verbatim to the caller.
+        BeforeAll {
+            $errorEnvelope = [PSCustomObject] @{
+                status        = 'ERROR'
+                'status-code' = 400
+                version       = '1.0'
+                data          = @()
+            }
+            Mock -CommandName Invoke-RestMethod -MockWith { $errorEnvelope } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'returns the API error envelope unmodified' -Test {
+            $result = Get-EPSS -CVE 'CVE-2022-27225'
+            $result.status        | Should -Be 'ERROR'
+            $result.'status-code' | Should -Be 400
+            $result.data          | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/Tests/Unit/Get-KEVList.tests.ps1
+++ b/Tests/Unit/Get-KEVList.tests.ps1
@@ -69,14 +69,14 @@ Describe -Name 'Get-KEVList' -Fixture {
     Context -Name 'OutputDirectory validation' -Fixture {
         It -Name 'throws when OutputDirectory does not exist' -Test {
             { Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/no-such-dir' } |
-                Should -Throw -ExpectedMessage '*Invalid output directory*'
+            Should -Throw -ExpectedMessage '*Invalid output directory*'
         }
 
         It -Name 'throws when OutputDirectory points at a file rather than a directory' -Test {
             $file = Join-Path -Path $TestDrive -ChildPath 'a-file.txt'
             Set-Content -Path $file -Value 'x'
             { Get-KEVList -Format 'JSON' -OutputDirectory $file } |
-                Should -Throw -ExpectedMessage '*Invalid output directory*'
+            Should -Throw -ExpectedMessage '*Invalid output directory*'
         }
     }
 
@@ -96,7 +96,7 @@ Describe -Name 'Get-KEVList' -Fixture {
                 throw [System.IO.IOException]::new('cannot write to OutFile')
             } -ModuleName $env:BHProjectName
             { Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/kev-fail' } |
-                Should -Throw -ExpectedMessage '*cannot write to OutFile*'
+            Should -Throw -ExpectedMessage '*cannot write to OutFile*'
         }
 
         It -Name 'propagates Invoke-RestMethod failures from the default path' -Test {

--- a/Tests/Unit/Get-KEVList.tests.ps1
+++ b/Tests/Unit/Get-KEVList.tests.ps1
@@ -46,5 +46,64 @@ Describe -Name 'Get-KEVList' -Fixture {
             Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/kev'
             Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -Times 1
         }
+
+        It -Name 'uses the CSV catalog URL when -Format CSV is specified' -Test {
+            Get-KEVList -Format 'CSV' -OutputDirectory 'TestDrive:/kev'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*known_exploited_vulnerabilities.csv' }
+        }
+
+        It -Name 'uses the schema URL when -Format Schema is specified' -Test {
+            Get-KEVList -Format 'Schema' -OutputDirectory 'TestDrive:/kev'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*known_exploited_vulnerabilities_schema.json' }
+        }
+
+        It -Name 'writes -OutFile under the supplied OutputDirectory' -Test {
+            Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/kev'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $OutFile -like '*kev*known_exploited_vulnerabilities.json' }
+        }
+    }
+
+    Context -Name 'OutputDirectory validation' -Fixture {
+        It -Name 'throws when OutputDirectory does not exist' -Test {
+            { Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/no-such-dir' } |
+                Should -Throw -ExpectedMessage '*Invalid output directory*'
+        }
+
+        It -Name 'throws when OutputDirectory points at a file rather than a directory' -Test {
+            $file = Join-Path -Path $TestDrive -ChildPath 'a-file.txt'
+            Set-Content -Path $file -Value 'x'
+            { Get-KEVList -Format 'JSON' -OutputDirectory $file } |
+                Should -Throw -ExpectedMessage '*Invalid output directory*'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an unknown -Format value' -Test {
+            { Get-KEVList -Format 'XML' -OutputDirectory 'TestDrive:/kev' } | Should -Throw
+        }
+    }
+
+    Context -Name 'transport / file-I/O failure' -Fixture {
+        BeforeAll {
+            New-Item -Path 'TestDrive:/kev-fail' -ItemType Directory -Force | Out-Null
+        }
+
+        It -Name 'propagates Invoke-WebRequest failures from the download path' -Test {
+            Mock -CommandName Invoke-WebRequest -MockWith {
+                throw [System.IO.IOException]::new('cannot write to OutFile')
+            } -ModuleName $env:BHProjectName
+            { Get-KEVList -Format 'JSON' -OutputDirectory 'TestDrive:/kev-fail' } |
+                Should -Throw -ExpectedMessage '*cannot write to OutFile*'
+        }
+
+        It -Name 'propagates Invoke-RestMethod failures from the default path' -Test {
+            Mock -CommandName Invoke-RestMethod -MockWith {
+                throw [System.Net.WebException]::new('feed unavailable')
+            } -ModuleName $env:BHProjectName
+            { Get-KEVList } | Should -Throw -ExpectedMessage '*feed unavailable*'
+        }
     }
 }

--- a/Tests/Unit/Get-LatestPowerShell.tests.ps1
+++ b/Tests/Unit/Get-LatestPowerShell.tests.ps1
@@ -1,0 +1,77 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-LatestPowerShell' -Fixture {
+
+    BeforeAll {
+        $script:LatestRelease = [PSCustomObject] @{ tag_name = 'v7.5.1' }
+
+        Mock -CommandName Invoke-RestMethod -MockWith { $script:LatestRelease } -ModuleName $env:BHProjectName
+        Mock -CommandName Invoke-WebRequest -MockWith {} -ModuleName $env:BHProjectName
+
+        New-Item -Path 'TestDrive:/pwsh-out' -ItemType Directory -Force | Out-Null
+    }
+
+    Context -Name 'version resolution' -Fixture {
+        It -Name 'calls the GitHub releases/latest API when -Version is omitted' -Test {
+            Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out'
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://api.github.com/repos/PowerShell/PowerShell/releases/latest' }
+        }
+
+        It -Name 'does NOT call the releases/latest API when -Version is supplied' -Test {
+            Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4.0'
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 0 -Exactly
+        }
+
+        It -Name 'strips the leading v from the tag name when building the URL' -Test {
+            Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out'
+            # tag_name is "v7.5.1"; the URL must contain "7.5.1" not "v7.5.1".
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*/v7.5.1/*' -and $Uri -notlike '*/vv7.5.1/*' }
+        }
+    }
+
+    Context -Name 'per-architecture URL' -Fixture {
+        It -Name 'uses the Windows MSI URL for WindowsAmd64' -Test {
+            Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4.0'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*PowerShell-7.4.0-win-x64.msi' }
+        }
+
+        It -Name 'uses the .deb URL for LinuxAmd64' -Test {
+            Get-LatestPowerShell -Architecture LinuxAmd64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4.0'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*powershell_7.4.0-1.deb_amd64.deb' }
+        }
+
+        It -Name 'uses the .tar.gz URL for LinuxArm64' -Test {
+            Get-LatestPowerShell -Architecture LinuxArm64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4.0'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like '*powershell-7.4.0-linux-arm64.tar.gz' }
+        }
+    }
+
+    Context -Name 'OutputDirectory plumbing' -Fixture {
+        It -Name 'writes -OutFile under the supplied OutputDirectory' -Test {
+            Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4.0'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $OutFile -like '*pwsh-out*PowerShell-7.4.0-win-x64.msi' }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an unknown -Architecture' -Test {
+            { Get-LatestPowerShell -Architecture 'MacArm64' -OutputDirectory 'TestDrive:/pwsh-out' } |
+                Should -Throw
+        }
+
+        It -Name 'rejects a malformed -Version' -Test {
+            { Get-LatestPowerShell -Architecture WindowsAmd64 -OutputDirectory 'TestDrive:/pwsh-out' -Version '7.4' } |
+                Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-PatchTuesday.tests.ps1
+++ b/Tests/Unit/Get-PatchTuesday.tests.ps1
@@ -1,0 +1,72 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-PatchTuesday' -Fixture {
+
+    Context -Name 'known-answer Patch Tuesdays' -Fixture {
+        # Verified against published Microsoft Patch Tuesday history.
+        # https://patchtuesday.com/
+        # Compare .Date to ignore sub-second drift from Get-Date -Hour 0 -Minute 0 -Second 0
+        # (which preserves the current millisecond component).
+        It -Name 'returns 2015-06-09 for June 2015' -Test {
+            (Get-PatchTuesday -Month 6 -Year 2015).Date | Should -Be ([DateTime] '2015-06-09')
+        }
+
+        It -Name 'returns 2024-01-09 for January 2024' -Test {
+            (Get-PatchTuesday -Month 1 -Year 2024).Date | Should -Be ([DateTime] '2024-01-09')
+        }
+
+        It -Name 'returns 2024-12-10 for December 2024' -Test {
+            (Get-PatchTuesday -Month 12 -Year 2024).Date | Should -Be ([DateTime] '2024-12-10')
+        }
+
+        It -Name 'handles a month where the 1st IS a Tuesday (Aug 2023 → 2023-08-08)' -Test {
+            # 2023-08-01 is a Tuesday, so the second Tuesday is 2023-08-08.
+            (Get-PatchTuesday -Month 8 -Year 2023).Date | Should -Be ([DateTime] '2023-08-08')
+        }
+    }
+
+    Context -Name 'arbitrary day-of-week / week-of-month' -Fixture {
+        It -Name 'returns the third Wednesday of June 2015 (2015-06-17)' -Test {
+            (Get-PatchTuesday -Month 6 -Year 2015 -DayOfWeek Wednesday -WeekOfMonth 3).Date |
+                Should -Be ([DateTime] '2015-06-17')
+        }
+
+        It -Name 'returns the first Monday of January 2024 (2024-01-01)' -Test {
+            (Get-PatchTuesday -Month 1 -Year 2024 -DayOfWeek Monday -WeekOfMonth 1).Date |
+                Should -Be ([DateTime] '2024-01-01')
+        }
+
+        It -Name 'accepts the WeekDay alias' -Test {
+            (Get-PatchTuesday -Month 6 -Year 2015 -WeekDay Wednesday -WeekOfMonth 3).Date |
+                Should -Be ([DateTime] '2015-06-17')
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects Month outside 1-12' -Test {
+            { Get-PatchTuesday -Month 13 -Year 2024 } | Should -Throw
+        }
+
+        It -Name 'rejects Year outside 1900-2301' -Test {
+            { Get-PatchTuesday -Month 1 -Year 1800 } | Should -Throw
+        }
+
+        It -Name 'rejects an unknown DayOfWeek' -Test {
+            { Get-PatchTuesday -Month 1 -Year 2024 -DayOfWeek 'Funday' } | Should -Throw
+        }
+
+        It -Name 'rejects WeekOfMonth outside 1-5' -Test {
+            { Get-PatchTuesday -Month 1 -Year 2024 -WeekOfMonth 6 } | Should -Throw
+        }
+    }
+
+    Context -Name 'return type' -Fixture {
+        It -Name 'returns a System.DateTime' -Test {
+            Get-PatchTuesday -Month 6 -Year 2015 | Should -BeOfType [System.DateTime]
+        }
+    }
+}

--- a/Tests/Unit/Get-StringHash.tests.ps1
+++ b/Tests/Unit/Get-StringHash.tests.ps1
@@ -1,0 +1,46 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-StringHash' -Fixture {
+
+    # Reference values computed from the canonical algorithms over UTF-8 bytes.
+    # These are stable and let us assert exact hash output (not just shape).
+    BeforeAll {
+        $script:Cases = @(
+            @{ Algorithm = 'MD5'   ; Input = ''      ; Expected = 'd41d8cd98f00b204e9800998ecf8427e' }
+            @{ Algorithm = 'SHA1'  ; Input = ''      ; Expected = 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }
+            @{ Algorithm = 'SHA256'; Input = ''      ; Expected = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' }
+            @{ Algorithm = 'SHA256'; Input = 'abc'   ; Expected = 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad' }
+            @{ Algorithm = 'SHA512'; Input = 'abc'   ; Expected = 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f' }
+        )
+    }
+
+    Context -Name 'known-answer hashes' -Fixture {
+        It -Name 'computes <Algorithm>("<Input>") = <Expected>' -ForEach $script:Cases -Test {
+            Get-StringHash -String $Input -Algorithm $Algorithm | Should -Be $Expected
+        }
+    }
+
+    Context -Name 'defaults' -Fixture {
+        It -Name 'defaults to SHA256' -Test {
+            Get-StringHash -String 'abc' |
+                Should -Be 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+        }
+    }
+
+    Context -Name 'pipeline' -Fixture {
+        It -Name 'accepts string input from the pipeline' -Test {
+            ('abc' | Get-StringHash -Algorithm SHA256) |
+                Should -Be 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an unknown algorithm' -Test {
+            { Get-StringHash -String 'abc' -Algorithm 'SHA3' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-UncPath.tests.ps1
+++ b/Tests/Unit/Get-UncPath.tests.ps1
@@ -18,6 +18,13 @@ Describe -Name 'Get-UncPath' -Fixture {
         }
     }
 
+    Context -Name 'Unix-style UNC' -Fixture {
+        It -Name 'builds a Unix-style UNC path with forward slashes' -Test {
+            Get-UncPath -Path 'C:\Temp\Share' -ComputerName 'MyServer' -Unix |
+                Should -Be '//MyServer/C$/Temp/Share'
+        }
+    }
+
     Context -Name 'ComputerName aliases' -Fixture {
         It -Name 'accepts -HostName as an alias for -ComputerName' -Test {
             Get-UncPath -Path 'C:\x' -HostName 'host2' | Should -Be '\\host2\C$\x'
@@ -29,6 +36,13 @@ Describe -Name 'Get-UncPath' -Fixture {
 
         It -Name 'accepts -Target as an alias for -ComputerName' -Test {
             Get-UncPath -Path 'C:\x' -Target 'host4' | Should -Be '\\host4\C$\x'
+        }
+    }
+
+    Context -Name 'pipeline input' -Fixture {
+        It -Name 'accepts a path from the pipeline' -Test {
+            ('E:\share\file.log' | Get-UncPath -ComputerName 'srv') |
+                Should -Be '\\srv\E$\share\file.log'
         }
     }
 

--- a/Tests/Unit/Get-UncPath.tests.ps1
+++ b/Tests/Unit/Get-UncPath.tests.ps1
@@ -1,0 +1,48 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-UncPath' -Fixture {
+
+    Context -Name 'Windows-style UNC (default)' -Fixture {
+        It -Name 'builds a UNC path with backslashes and the dollar-sign drive' -Test {
+            Get-UncPath -Path 'C:\Temp\Share' -ComputerName 'MyServer' |
+                Should -Be '\\MyServer\C$\Temp\Share'
+        }
+
+        It -Name 'preserves nested directories' -Test {
+            Get-UncPath -Path 'D:\a\b\c\file.txt' -ComputerName 'host1' |
+                Should -Be '\\host1\D$\a\b\c\file.txt'
+        }
+    }
+
+    Context -Name 'ComputerName aliases' -Fixture {
+        It -Name 'accepts -HostName as an alias for -ComputerName' -Test {
+            Get-UncPath -Path 'C:\x' -HostName 'host2' | Should -Be '\\host2\C$\x'
+        }
+
+        It -Name 'accepts -CN as an alias for -ComputerName' -Test {
+            Get-UncPath -Path 'C:\x' -CN 'host3' | Should -Be '\\host3\C$\x'
+        }
+
+        It -Name 'accepts -Target as an alias for -ComputerName' -Test {
+            Get-UncPath -Path 'C:\x' -Target 'host4' | Should -Be '\\host4\C$\x'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a path without a drive letter' -Test {
+            { Get-UncPath -Path '/etc/passwd' -ComputerName 'srv' } | Should -Throw
+        }
+
+        It -Name 'rejects an empty path' -Test {
+            { Get-UncPath -Path '' -ComputerName 'srv' } | Should -Throw
+        }
+
+        It -Name 'rejects a bare drive letter (must include subpath)' -Test {
+            { Get-UncPath -Path 'C:\' -ComputerName 'srv' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Out-MeasureResult.tests.ps1
+++ b/Tests/Unit/Out-MeasureResult.tests.ps1
@@ -1,0 +1,63 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Out-MeasureResult' -Fixture {
+
+    Context -Name 'aggregates a TimeSpan collection' -Fixture {
+        BeforeAll {
+            # 100ms, 200ms, 300ms → max=300, min=100, avg=200
+            $script:Spans = @(
+                [TimeSpan]::FromMilliseconds(100)
+                [TimeSpan]::FromMilliseconds(200)
+                [TimeSpan]::FromMilliseconds(300)
+            )
+        }
+
+        It -Name 'reports MaxMilliseconds from the longest TimeSpan' -Test {
+            ($script:Spans | Out-MeasureResult).MaxMilliseconds | Should -Be 300
+        }
+
+        It -Name 'reports MinMilliseconds from the shortest TimeSpan' -Test {
+            ($script:Spans | Out-MeasureResult).MinMilliseconds | Should -Be 100
+        }
+
+        It -Name 'reports AvgMilliseconds from the arithmetic mean' -Test {
+            ($script:Spans | Out-MeasureResult).AvgMilliseconds | Should -Be 200
+        }
+    }
+
+    Context -Name 'output shape' -Fixture {
+        It -Name 'returns a single PSCustomObject with the expected properties' -Test {
+            $result = @([TimeSpan]::FromMilliseconds(50)) | Out-MeasureResult
+            $result | Should -BeOfType [System.Management.Automation.PSCustomObject]
+            $result.PSObject.Properties.Name | Should -Contain 'MaxMilliseconds'
+            $result.PSObject.Properties.Name | Should -Contain 'MinMilliseconds'
+            $result.PSObject.Properties.Name | Should -Contain 'AvgMilliseconds'
+        }
+
+        It -Name 'all three values equal the only TimeSpan when a single measurement is supplied' -Test {
+            $result = @([TimeSpan]::FromMilliseconds(42)) | Out-MeasureResult
+            $result.MaxMilliseconds | Should -Be 42
+            $result.MinMilliseconds | Should -Be 42
+            $result.AvgMilliseconds | Should -Be 42
+        }
+    }
+
+    Context -Name 'array argument vs pipeline' -Fixture {
+        It -Name 'aggregates identically whether passed via -Measurement or piped' -Test {
+            $spans = @(
+                [TimeSpan]::FromMilliseconds(10)
+                [TimeSpan]::FromMilliseconds(20)
+                [TimeSpan]::FromMilliseconds(30)
+            )
+            $viaParam = Out-MeasureResult -Measurement $spans
+            $viaPipe = $spans | Out-MeasureResult
+            $viaParam.MaxMilliseconds | Should -Be $viaPipe.MaxMilliseconds
+            $viaParam.MinMilliseconds | Should -Be $viaPipe.MinMilliseconds
+            $viaParam.AvgMilliseconds | Should -Be $viaPipe.AvgMilliseconds
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three slices from the issue #109 audit, plus two latent fixes surfaced while writing the D7 tests.

### Group B — "good but missing error paths"

- **`Get-CVSSv3BaseScore`** — malformed/non-matching HTML emits the "No CVSS v3 score found" warning with no pipeline output; empty content does not throw; transport errors propagate.
- **`Get-EPSS`** — comma-joined multi-CVE array argument (single request, vs pipeline iteration); rate-limit / transport errors propagate from both lookup and bulk paths; non-success API envelopes surfaced unmodified.
- **`Get-KEVList`** — CSV / Schema format URLs; `-OutFile` path is built under the supplied `OutputDirectory`; `OutputDirectory` validation rejects missing dirs and files-as-dirs; unknown `-Format` rejected; `Invoke-WebRequest` and `Invoke-RestMethod` failures propagate.

Note: the fourth Group B item — `Set-GitHubBranchProtection` — was completed in PR #110.

### Group D7 — Utility (6 fns, all previously without unit tests)

- **`Get-StringHash`** — known-answer hashes for MD5/SHA1/SHA256/SHA512 (RFC vectors).
- **`Get-CountryCode`** — Alpha-2 / Alpha-3 / country-substring lookup against a mocked ISO-3166 CSV; single-fetch caching across multiple lookups; parameter validation.
- **`Get-PatchTuesday`** — known-answer Patch Tuesdays (Jun 2015, Jan 2024, Dec 2024, plus the Aug 2023 edge case where the 1st IS a Tuesday); arbitrary day-of-week / week-of-month; `-WeekDay` alias; parameter validation; return type.
- **`Get-LatestPowerShell`** — calls releases/latest only when `-Version` is omitted; strips leading `v` from the tag; correct per-architecture URLs for WindowsAmd64 / LinuxAmd64 / LinuxArm64; `-OutFile` plumbed under `OutputDirectory`; parameter validation.
- **`Get-UncPath`** — Windows + Unix UNC construction, nested directories, all four `-ComputerName` aliases, pipeline input, parameter validation.
- **`Out-MeasureResult`** — Max/Min/Avg ms aggregation of a TimeSpan collection; output shape; single-measurement parity; `-Measurement` parameter and pipeline produce identical output.

### Function fixes (surfaced by the D7 tests)

- **`Get-UncPath`**: add `ValueFromPipeline` to `-Path` so paths can be piped in (matches the README example).
- **`Get-UncPath`**: stop mutating `$Path` under `-Unix` — reassigning the parameter to its forward-slash form re-triggered `[ValidatePattern("[A-Z]:\\.+")]` and threw `ValidationMetadataException`. Now uses a local `$unixPath`.

### Manifest cleanup

- Remove the `Get-Object` export from `SecurityTools.psd1`. There was no source file under `Public/` — pure orphan.

Net: **+48 tests**; suite is **792 passed / 2 skipped** locally.

Partially closes #109.

## Test plan

- [x] `./Build/build.ps1 -TaskList Test, Cleanup` passes locally on macOS (PS 7.6.2)
- [ ] CI passes on `ubuntu-latest`