### PR TITLE
test(SecurityTools): add D5 conversion/formatting test coverage (refs #109)

### DIFF
--- a/Public/Convert-Hexadecimal.ps1
+++ b/Public/Convert-Hexadecimal.ps1
@@ -37,9 +37,9 @@ function Convert-Hexadecimal {
         switch ($PSCmdlet.ParameterSetName) {
             '__hex' {
                 # CONVERT HEXADECIMAL TO DECIMAL
-                #'{0:d}' -f 0x1098
-                #[System.String]::Format('{0:d}', 0x7C2)
-                [System.Convert]::ToString($Hexadecimal, 10)
+                # Strip an optional 0x/0X prefix so '0x1098' and '1098' both work.
+                $trimmed = $Hexadecimal -replace '^0[xX]', ''
+                [System.Convert]::ToInt64($trimmed, 16).ToString()
             }
             '__dcm' {
                 # CONVERT DECIMAL TO HEXADECIMAL

--- a/Public/ConvertFrom-IISLog.ps1
+++ b/Public/ConvertFrom-IISLog.ps1
@@ -19,7 +19,9 @@ function ConvertFrom-IISLog {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline, HelpMessage = 'Path to IIS log file')]
-        [ValidateScript({ Test-Path -Path $_ -PathType Leaf -Filter "*.log" })]
+        [ValidateScript({
+            (Test-Path -Path $_ -PathType Leaf) -and ((Split-Path -Path $_ -Extension) -ieq '.log')
+        })]
         [System.String] $Path
     )
     Begin {

--- a/Tests/Unit/Compress-URL.tests.ps1
+++ b/Tests/Unit/Compress-URL.tests.ps1
@@ -1,0 +1,54 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Compress-URL' -Fixture {
+
+    BeforeAll {
+        $script:MockResponse = [PSCustomObject] @{
+            success = $true
+            data    = [PSCustomObject] @{
+                short_url = 'https://1simpl.io/abc123'
+                long_url  = 'https://www.example.com/some/long/path'
+            }
+        }
+
+        Mock -CommandName Invoke-RestMethod -MockWith { $script:MockResponse } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'POSTs to the onesimpleapi shortener endpoint' -Test {
+            Compress-URL -URL 'https://www.example.com/some/long/path' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'https://onesimpleapi.com/api/shortener/new' -and $Method -eq 'POST'
+            }
+        }
+
+        It -Name 'passes the API key, output=json, and URL in the request body' -Test {
+            Compress-URL -URL 'https://www.example.com/' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Body.token -eq 'fake-key' -and
+                $Body.output -eq 'json' -and
+                $Body.url -eq 'https://www.example.com/'
+            }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'returns the mocked response unchanged' -Test {
+            $result = Compress-URL -URL 'https://www.example.com/' -ApiKey 'fake-key'
+            $result.success        | Should -BeTrue
+            $result.data.short_url | Should -Be 'https://1simpl.io/abc123'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -ApiKey' -Test {
+            { Compress-URL -URL 'https://example.com/' -ApiKey '' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Convert-Epoch.tests.ps1
+++ b/Tests/Unit/Convert-Epoch.tests.ps1
@@ -1,0 +1,49 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Convert-Epoch' -Fixture {
+
+    Context -Name 'seconds → DateTime' -Fixture {
+        It -Name 'converts 0 to the Unix epoch (1970-01-01 UTC)' -Test {
+            $result = Convert-Epoch -Seconds 0
+            $result.ToUniversalTime() | Should -Be ([DateTime] '1970-01-01T00:00:00Z').ToUniversalTime()
+        }
+
+        It -Name 'converts 1577836800 to 2020-01-01T00:00:00Z (verified Unix time)' -Test {
+            $result = Convert-Epoch -Seconds 1577836800
+            $result.ToUniversalTime() | Should -Be ([DateTime]::new(2020, 1, 1, 0, 0, 0, [DateTimeKind]::Utc))
+        }
+    }
+
+    Context -Name 'milliseconds → DateTime' -Fixture {
+        It -Name 'converts 1577836800000 ms identically to 1577836800 s' -Test {
+            $fromSec = Convert-Epoch -Seconds 1577836800
+            $fromMs = Convert-Epoch -Milliseconds 1577836800000
+            $fromMs | Should -Be $fromSec
+        }
+    }
+
+    Context -Name 'DateTime → epoch (default parameter set)' -Fixture {
+        It -Name 'returns an object with Date / Seconds / Milliseconds properties' -Test {
+            $result = Convert-Epoch -Date ([DateTime] '2020-01-01T00:00:00Z')
+            $result.PSObject.Properties.Name | Should -Contain 'Date'
+            $result.PSObject.Properties.Name | Should -Contain 'Seconds'
+            $result.PSObject.Properties.Name | Should -Contain 'Milliseconds'
+        }
+
+        It -Name 'reports 1577836800 seconds for 2020-01-01T00:00:00Z' -Test {
+            $result = Convert-Epoch -Date ([DateTime]::new(2020, 1, 1, 0, 0, 0, [DateTimeKind]::Utc))
+            $result.Seconds      | Should -Be 1577836800
+            $result.Milliseconds | Should -Be 1577836800000
+        }
+    }
+
+    Context -Name 'parameter set conflicts' -Fixture {
+        It -Name 'rejects -Seconds and -Milliseconds supplied together' -Test {
+            { Convert-Epoch -Seconds 1 -Milliseconds 1000 } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Convert-Hexadecimal.tests.ps1
+++ b/Tests/Unit/Convert-Hexadecimal.tests.ps1
@@ -21,6 +21,20 @@ Describe -Name 'Convert-Hexadecimal' -Fixture {
         }
     }
 
+    Context -Name 'hexadecimal → decimal' -Fixture {
+        It -Name 'converts 1098 to 4248' -Test {
+            Convert-Hexadecimal -Hexadecimal '1098' | Should -Be '4248'
+        }
+
+        It -Name 'accepts an optional 0x prefix' -Test {
+            Convert-Hexadecimal -Hexadecimal '0x1098' | Should -Be '4248'
+        }
+
+        It -Name 'accepts lowercase hex digits' -Test {
+            Convert-Hexadecimal -Hexadecimal 'ff' | Should -Be '255'
+        }
+    }
+
     Context -Name 'parameter set conflicts' -Fixture {
         It -Name 'rejects -Hexadecimal and -Decimal supplied together' -Test {
             { Convert-Hexadecimal -Hexadecimal '1098' -Decimal '4248' } | Should -Throw

--- a/Tests/Unit/Convert-Hexadecimal.tests.ps1
+++ b/Tests/Unit/Convert-Hexadecimal.tests.ps1
@@ -1,0 +1,29 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Convert-Hexadecimal' -Fixture {
+
+    Context -Name 'decimal → hexadecimal (default set)' -Fixture {
+        It -Name 'converts 4248 to 0x1098' -Test {
+            Convert-Hexadecimal -Decimal '4248' | Should -Be '0x1098'
+        }
+
+        It -Name 'converts 0 to 0x0' -Test {
+            Convert-Hexadecimal -Decimal '0' | Should -Be '0x0'
+        }
+
+        It -Name 'returns lowercase hex digits (per [Convert]::ToString base 16)' -Test {
+            # 255 → 'ff' (lowercase from [Convert]::ToString)
+            Convert-Hexadecimal -Decimal '255' | Should -Be '0xff'
+        }
+    }
+
+    Context -Name 'parameter set conflicts' -Fixture {
+        It -Name 'rejects -Hexadecimal and -Decimal supplied together' -Test {
+            { Convert-Hexadecimal -Hexadecimal '1098' -Decimal '4248' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/ConvertFrom-Encoding.tests.ps1
+++ b/Tests/Unit/ConvertFrom-Encoding.tests.ps1
@@ -1,0 +1,48 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertFrom-Encoding' -Fixture {
+
+    Context -Name 'Base64 decode (default)' -Fixture {
+        It -Name "decodes 'SGVsbG8sIFdvcmxkIQ==' to 'Hello, World!'" -Test {
+            ConvertFrom-Encoding -String 'SGVsbG8sIFdvcmxkIQ==' | Should -Be 'Hello, World!'
+        }
+
+        It -Name 'round-trips with ConvertTo-Encoding' -Test {
+            $plain = 'The quick brown fox jumps over the lazy dog.'
+            $encoded = ConvertTo-Encoding -String $plain
+            ConvertFrom-Encoding -String $encoded | Should -Be $plain
+        }
+
+        It -Name 'decodes UTF-8 byte sequences (multi-byte characters)' -Test {
+            # 'café' is 5 bytes in UTF-8 → 'Y2Fmw6k='
+            ConvertFrom-Encoding -String 'Y2Fmw6k=' | Should -Be 'café'
+        }
+
+        It -Name 'rejects a non-Base64 string' -Test {
+            { ConvertFrom-Encoding -String '!not-base64!' } | Should -Throw
+        }
+    }
+
+    Context -Name 'URL decode' -Fixture {
+        It -Name "decodes percent-escapes back to 'https://google.com/?q=hello world'" -Test {
+            ConvertFrom-Encoding -String 'https%3A%2F%2Fgoogle.com%2F%3Fq%3Dhello%20world' -Encoding URL |
+            Should -Be 'https://google.com/?q=hello world'
+        }
+
+        It -Name 'round-trips with ConvertTo-Encoding -Encoding URL' -Test {
+            $plain = 'a b/c?d=e&f=g'
+            $encoded = ConvertTo-Encoding -String $plain -Encoding URL
+            ConvertFrom-Encoding -String $encoded -Encoding URL | Should -Be $plain
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an unknown -Encoding value' -Test {
+            { ConvertFrom-Encoding -String 'abc' -Encoding 'Rot13' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/ConvertFrom-GZipString.tests.ps1
+++ b/Tests/Unit/ConvertFrom-GZipString.tests.ps1
@@ -1,0 +1,56 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertFrom-GZipString' -Fixture {
+
+    BeforeAll {
+        # Build a known Base64-gzipped fixture using the same .NET APIs the function uses.
+        function New-GZipFixture {
+            param([string] $Text)
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+            $ms = [System.IO.MemoryStream]::new()
+            $gz = [System.IO.Compression.GZipStream]::new($ms, [System.IO.Compression.CompressionMode]::Compress)
+            $gz.Write($bytes, 0, $bytes.Length)
+            $gz.Dispose()
+            [System.Convert]::ToBase64String($ms.ToArray())
+        }
+    }
+
+    Context -Name 'round-trip' -Fixture {
+        It -Name 'decompresses a Base64-gzipped string back to the original' -Test {
+            $original = 'The quick brown fox jumps over the lazy dog.'
+            $fixture = New-GZipFixture -Text $original
+            ConvertFrom-GZipString -String $fixture | Should -Be $original
+        }
+
+        It -Name 'preserves multi-line content' -Test {
+            $original = "line one`nline two`nline three"
+            $fixture = New-GZipFixture -Text $original
+            ConvertFrom-GZipString -String $fixture | Should -Be $original
+        }
+
+        It -Name 'preserves UTF-8 multi-byte characters' -Test {
+            $original = 'café — résumé — 北京'
+            $fixture = New-GZipFixture -Text $original
+            ConvertFrom-GZipString -String $fixture | Should -Be $original
+        }
+    }
+
+    Context -Name 'pipeline + array input' -Fixture {
+        It -Name 'decompresses each item when an array is piped in' -Test {
+            $a = New-GZipFixture -Text 'first'
+            $b = New-GZipFixture -Text 'second'
+            $result = $a, $b | ConvertFrom-GZipString
+            $result | Should -Be @('first', 'second')
+        }
+    }
+
+    Context -Name 'error cases' -Fixture {
+        It -Name 'rejects a non-Base64 string' -Test {
+            { ConvertFrom-GZipString -String '!not-base64!' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/ConvertFrom-IISLog.tests.ps1
+++ b/Tests/Unit/ConvertFrom-IISLog.tests.ps1
@@ -1,0 +1,53 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertFrom-IISLog' -Fixture {
+
+    BeforeAll {
+        # Minimal IIS W3C log: software/version/date headers, a #Fields header, and two data rows.
+        $script:LogContent = @'
+#Software: Microsoft Internet Information Services 10.0
+#Version: 1.0
+#Date: 2024-01-15 00:00:00
+#Fields: date time c-ip cs-method cs-uri-stem sc-status
+2024-01-15 00:00:01 10.0.0.1 GET /index.html 200
+2024-01-15 00:00:02 10.0.0.2 POST /api/login 401
+'@
+
+        $script:LogPath = Join-Path -Path 'TestDrive:' -ChildPath 'sample.log'
+        Set-Content -Path $script:LogPath -Value $script:LogContent
+    }
+
+    Context -Name 'parses W3C-formatted log lines' -Fixture {
+        It -Name 'returns one PSCustomObject per non-comment line' -Test {
+            $result = ConvertFrom-IISLog -Path $script:LogPath
+            $result.Count | Should -Be 2
+        }
+
+        It -Name 'maps #Fields header tokens to property names' -Test {
+            $result = ConvertFrom-IISLog -Path $script:LogPath
+            $result[0].PSObject.Properties.Name | Should -Contain 'date'
+            $result[0].PSObject.Properties.Name | Should -Contain 'cs-method'
+            $result[0].PSObject.Properties.Name | Should -Contain 'sc-status'
+        }
+
+        It -Name 'populates each property from the matching position in the data row' -Test {
+            $result = ConvertFrom-IISLog -Path $script:LogPath
+            $result[0].'c-ip'        | Should -Be '10.0.0.1'
+            $result[0].'cs-method'   | Should -Be 'GET'
+            $result[0].'cs-uri-stem' | Should -Be '/index.html'
+            $result[0].'sc-status'   | Should -Be '200'
+            $result[1].'cs-method'   | Should -Be 'POST'
+            $result[1].'sc-status'   | Should -Be '401'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a non-existent path' -Test {
+            { ConvertFrom-IISLog -Path 'TestDrive:/missing.log' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/ConvertFrom-IISLog.tests.ps1
+++ b/Tests/Unit/ConvertFrom-IISLog.tests.ps1
@@ -49,5 +49,11 @@ Describe -Name 'ConvertFrom-IISLog' -Fixture {
         It -Name 'rejects a non-existent path' -Test {
             { ConvertFrom-IISLog -Path 'TestDrive:/missing.log' } | Should -Throw
         }
+
+        It -Name 'rejects a path that does not end in .log' -Test {
+            $badPath = Join-Path -Path 'TestDrive:' -ChildPath 'sample.txt'
+            Set-Content -Path $badPath -Value 'whatever'
+            { ConvertFrom-IISLog -Path $badPath } | Should -Throw
+        }
     }
 }

--- a/Tests/Unit/ConvertTo-Encoding.tests.ps1
+++ b/Tests/Unit/ConvertTo-Encoding.tests.ps1
@@ -1,0 +1,51 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertTo-Encoding' -Fixture {
+
+    Context -Name 'Base64 encode (default)' -Fixture {
+        It -Name "encodes 'Hello, World!' to 'SGVsbG8sIFdvcmxkIQ=='" -Test {
+            ConvertTo-Encoding -String 'Hello, World!' | Should -Be 'SGVsbG8sIFdvcmxkIQ=='
+        }
+
+        It -Name 'encodes UTF-8 multi-byte characters correctly' -Test {
+            # 'café' → 'Y2Fmw6k=' (5 UTF-8 bytes)
+            ConvertTo-Encoding -String 'café' | Should -Be 'Y2Fmw6k='
+        }
+
+        It -Name 'round-trips through ConvertFrom-Encoding' -Test {
+            $plain = 'round-trip me 1234 !@#$%^&*()'
+            ConvertFrom-Encoding -String (ConvertTo-Encoding -String $plain) | Should -Be $plain
+        }
+    }
+
+    Context -Name 'URL encode' -Fixture {
+        It -Name "encodes 'https://google.com/' to percent-escapes" -Test {
+            ConvertTo-Encoding -String 'https://google.com/' -Encoding URL |
+            Should -Be 'https%3A%2F%2Fgoogle.com%2F'
+        }
+
+        It -Name 'escapes spaces as %20 (RFC 3986), not as plus signs' -Test {
+            ConvertTo-Encoding -String 'a b' -Encoding URL | Should -Be 'a%20b'
+        }
+    }
+
+    Context -Name 'pipeline input' -Fixture {
+        It -Name 'accepts strings from the pipeline' -Test {
+            ('test' | ConvertTo-Encoding) | Should -Be 'dGVzdA=='
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty string' -Test {
+            { ConvertTo-Encoding -String '' } | Should -Throw
+        }
+
+        It -Name 'rejects an unknown -Encoding value' -Test {
+            { ConvertTo-Encoding -String 'abc' -Encoding 'Rot13' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/ConvertTo-FlatObject.tests.ps1
+++ b/Tests/Unit/ConvertTo-FlatObject.tests.ps1
@@ -1,0 +1,55 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertTo-FlatObject' -Fixture {
+
+    Context -Name 'flat object passthrough' -Fixture {
+        It -Name 'returns the same properties when the object is already flat' -Test {
+            $obj = [PSCustomObject] @{ Name = 'alpha'; Value = 1 }
+            $result = ConvertTo-FlatObject -Object $obj
+            $result.Name  | Should -Be 'alpha'
+            $result.Value | Should -Be 1
+        }
+    }
+
+    Context -Name 'nested object flattening' -Fixture {
+        It -Name 'joins nested property names with the default "." separator' -Test {
+            $obj = [PSCustomObject] @{
+                Outer = [PSCustomObject] @{ Inner = 'value' }
+            }
+            $result = ConvertTo-FlatObject -Object $obj
+            $result.'Outer.Inner' | Should -Be 'value'
+        }
+
+        It -Name 'honors a custom -Separator' -Test {
+            $obj = [PSCustomObject] @{
+                Outer = [PSCustomObject] @{ Inner = 'value' }
+            }
+            $result = ConvertTo-FlatObject -Object $obj -Separator '__'
+            $result.'Outer__Inner' | Should -Be 'value'
+        }
+    }
+
+    Context -Name 'ExcludeProperty' -Fixture {
+        It -Name 'omits any property whose name is listed in -ExcludeProperty' -Test {
+            $obj = [PSCustomObject] @{ Keep = 1; Drop = 2 }
+            $result = ConvertTo-FlatObject -Object $obj -ExcludeProperty 'Drop'
+            $result.PSObject.Properties.Name | Should -Contain 'Keep'
+            $result.PSObject.Properties.Name | Should -Not -Contain 'Drop'
+        }
+    }
+
+    Context -Name 'pipeline + multiple inputs' -Fixture {
+        It -Name 'emits one flat object per piped input' -Test {
+            $a = [PSCustomObject] @{ X = 1 }
+            $b = [PSCustomObject] @{ X = 2 }
+            $result = @($a, $b) | ConvertTo-FlatObject
+            $result.Count | Should -Be 2
+            $result[0].X | Should -Be 1
+            $result[1].X | Should -Be 2
+        }
+    }
+}

--- a/Tests/Unit/ConvertTo-Hex.tests.ps1
+++ b/Tests/Unit/ConvertTo-Hex.tests.ps1
@@ -1,0 +1,53 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertTo-Hex' -Fixture {
+
+    Context -Name 'single character' -Fixture {
+        It -Name "returns 0x41 for 'A' (ASCII 65)" -Test {
+            $result = ConvertTo-Hex -Character 'A'
+            $result.Char | Should -Be 'A'
+            $result.Hex  | Should -Be '0x41'
+        }
+
+        It -Name "returns 0x30 for '0' (ASCII 48)" -Test {
+            (ConvertTo-Hex -Character '0').Hex | Should -Be '0x30'
+        }
+
+        It -Name "returns 0x20 for ' ' (space, ASCII 32)" -Test {
+            (ConvertTo-Hex -Character ' ').Hex | Should -Be '0x20'
+        }
+    }
+
+    Context -Name 'multi-character input' -Fixture {
+        It -Name "emits one PSCustomObject per character in 'AB'" -Test {
+            $result = ConvertTo-Hex -Character 'A', 'B'
+            $result.Count | Should -Be 2
+            $result[0].Hex | Should -Be '0x41'
+            $result[1].Hex | Should -Be '0x42'
+        }
+    }
+
+    Context -Name 'pipeline input' -Fixture {
+        It -Name 'accepts characters from the pipeline' -Test {
+            $result = 'A', 'B', 'C' | ForEach-Object { [char] $_ } | ConvertTo-Hex
+            $result.Hex | Should -Be @('0x41', '0x42', '0x43')
+        }
+    }
+
+    Context -Name 'output shape' -Fixture {
+        It -Name 'returns objects with Char and Hex properties' -Test {
+            $result = ConvertTo-Hex -Character 'Z'
+            $result.PSObject.Properties.Name | Should -Contain 'Char'
+            $result.PSObject.Properties.Name | Should -Contain 'Hex'
+        }
+
+        It -Name 'always produces 0x followed by exactly two uppercase hex digits' -Test {
+            (ConvertTo-Hex -Character 'a').Hex | Should -CMatch '^0x[0-9A-F]{2}$'
+            (ConvertTo-Hex -Character '~').Hex | Should -CMatch '^0x[0-9A-F]{2}$'
+        }
+    }
+}

--- a/Tests/Unit/ConvertTo-MarkdownTable.tests.ps1
+++ b/Tests/Unit/ConvertTo-MarkdownTable.tests.ps1
@@ -1,0 +1,41 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'ConvertTo-MarkdownTable' -Fixture {
+
+    Context -Name 'header + body' -Fixture {
+        It -Name 'emits a header row, separator row, and one data row per input' -Test {
+            $rows = @(
+                [PSCustomObject] @{ Name = 'alpha'; Value = 1 }
+                [PSCustomObject] @{ Name = 'beta' ; Value = 2 }
+            )
+            $result = $rows | ConvertTo-MarkdownTable
+            $result.Count | Should -Be 4
+            $result[0] | Should -Be '| Name | Value |'
+            # second row is the dashed separator — same width per column as the header letters
+            $result[1] | Should -Be '| ---- | ----- |'
+            $result[2] | Should -Be '| alpha | 1 |'
+            $result[3] | Should -Be '| beta | 2 |'
+        }
+    }
+
+    Context -Name 'pipe escaping' -Fixture {
+        It -Name 'escapes pipe characters in values so they do not break the table' -Test {
+            $row = [PSCustomObject] @{ Col = 'left|right' }
+            $result = $row | ConvertTo-MarkdownTable
+            # Header (no pipe in name), separator, then the data row with the escaped pipe
+            $result[-1] | Should -Be '| left\|right |'
+        }
+    }
+
+    Context -Name 'single column / single row' -Fixture {
+        It -Name 'still emits the three-line structure for a single column' -Test {
+            $result = ([PSCustomObject] @{ Only = 'value' }) | ConvertTo-MarkdownTable
+            $result.Count | Should -Be 3
+            $result[0] | Should -Be '| Only |'
+        }
+    }
+}

--- a/Tests/Unit/Export-NPMAudit.tests.ps1
+++ b/Tests/Unit/Export-NPMAudit.tests.ps1
@@ -1,0 +1,98 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-NPMAudit' -Fixture {
+
+    BeforeAll {
+        # Minimal NPM audit JSON shape covering the fields the function reads.
+        $script:AuditFixture = @{
+            actions    = @(
+                @{
+                    action   = 'install'
+                    module   = 'lodash'
+                    depth    = 1
+                    isMajor  = $false
+                    resolves = @(@{ id = 1500 })
+                }
+            )
+            advisories = @{
+                '1500' = @{
+                    title               = 'Prototype Pollution'
+                    cves                = @('CVE-2020-1234')
+                    module_name         = 'lodash'
+                    vulnerable_versions = '<4.17.20'
+                    patched_versions    = '>=4.17.20'
+                    severity            = 'high'
+                    cwe                 = 'CWE-1321'
+                    updated             = '2020-07-15'
+                    recommendation      = 'Upgrade to 4.17.20'
+                    references          = 'https://example.com'
+                    overview            = 'Prototype pollution in lodash'
+                    url                 = 'https://example.com/advisories/1500'
+                    findings            = @(
+                        @{ version = '4.17.19'; paths = @('node_modules/lodash') }
+                    )
+                }
+            }
+            metadata   = @{
+                vulnerabilities = @{
+                    info     = 0
+                    low      = 0
+                    moderate = 0
+                    high     = 1
+                    critical = 0
+                }
+            }
+        }
+
+        $script:JsonPath = Join-Path -Path 'TestDrive:' -ChildPath 'audit.json'
+        $script:AuditFixture | ConvertTo-Json -Depth 8 | Set-Content -Path $script:JsonPath
+
+        $script:OutDir = Join-Path -Path 'TestDrive:' -ChildPath 'out'
+        New-Item -Path $script:OutDir -ItemType Directory -Force | Out-Null
+
+        # Replace Excel I/O and CVSS lookup so the test stays hermetic.
+        Mock -CommandName Export-Excel    -MockWith {} -ModuleName $env:BHProjectName
+        Mock -CommandName New-ExcelStyle  -MockWith { @{} } -ModuleName $env:BHProjectName
+        Mock -CommandName Get-CVSSv3BaseScore -ModuleName $env:BHProjectName -MockWith {
+            [PSCustomObject] @{ CVE = 'CVE-2020-1234'; Severity = 'HIGH'; Score = 7.5; Vector = 'AV:N' }
+        }
+    }
+
+    Context -Name 'workbook export' -Fixture {
+        It -Name 'writes three worksheets: Info, Actions, Advisories' -Test {
+            Export-NPMAudit -Path $script:JsonPath -OutputDirectory $script:OutDir
+            # Pester counts each pipeline item as a separate Mock invocation, so don't
+            # assert exact call counts — just verify each worksheet name was used.
+            foreach ($sheet in 'Info', 'Actions', 'Advisories') {
+                Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                    -ParameterFilter { $WorksheetName -eq $sheet }
+            }
+        }
+
+        It -Name 'writes the workbook under the supplied -OutputDirectory' -Test {
+            Export-NPMAudit -Path $script:JsonPath -OutputDirectory $script:OutDir
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Path -like '*out*NPM-Audit_*.xlsx' }
+        }
+
+        It -Name 'looks up the CVSS score for each advisory CVE' -Test {
+            Export-NPMAudit -Path $script:JsonPath -OutputDirectory $script:OutDir
+            Should -Invoke -CommandName Get-CVSSv3BaseScore -ModuleName $env:BHProjectName `
+                -ParameterFilter { $CVE -eq 'CVE-2020-1234' }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a non-existent input file' -Test {
+            { Export-NPMAudit -Path 'TestDrive:/missing.json' -OutputDirectory $script:OutDir } | Should -Throw
+        }
+
+        It -Name 'rejects a non-existent OutputDirectory' -Test {
+            { Export-NPMAudit -Path $script:JsonPath -OutputDirectory 'TestDrive:/no-such-dir' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the D5 slice from issue #109 — eleven conversion/formatting helpers that had no dedicated test file, plus two bug fixes uncovered while writing the tests. (refs #109 — kept as a plain reference so merging this PR does not auto-close the umbrella issue.)

### New test files (+60 tests)

- **`Convert-Epoch`** — seconds/ms → DateTime, DateTime → epoch object shape, known-answer values, parameter-set conflict.
- **`Convert-Hexadecimal`** — decimal → hex round-numbers, lowercase output, hex → decimal with/without `0x` prefix, parameter-set conflict.
- **`ConvertTo-Hex`** — known-answer ASCII conversions, multi-char array input, pipeline input, output shape.
- **`ConvertFrom-Encoding`** — Base64 + URL decode, UTF-8 multi-byte, round-trip with `ConvertTo-Encoding`, invalid Base64 / unknown -Encoding rejection.
- **`ConvertTo-Encoding`** — Base64 + URL encode, UTF-8 multi-byte, RFC 3986 space escaping, pipeline input, parameter validation.
- **`ConvertFrom-GZipString`** — round-trip with a hermetic in-memory gzip fixture, multi-line preservation, UTF-8 preservation, array/pipeline input, invalid Base64 rejection.
- **`ConvertTo-FlatObject`** — flat passthrough, nested flattening with default and custom `-Separator`, `-ExcludeProperty`, pipeline + multi-input.
- **`ConvertTo-MarkdownTable`** — header + separator + body row structure, pipe-character escaping, single-column tables.
- **`ConvertFrom-IISLog`** — W3C-formatted log parsing using a TestDrive fixture (header mapping, per-position field population), non-existent-path rejection, non-`.log` extension rejection.
- **`Compress-URL`** — mocks `Invoke-RestMethod`; asserts endpoint URL, method, body (token / output / url), response passthrough, empty `-ApiKey` rejection.
- **`Export-NPMAudit`** — mocks `Export-Excel`, `New-ExcelStyle`, `Get-CVSSv3BaseScore`; asserts three worksheets (Info / Actions / Advisories), output path under `-OutputDirectory`, per-CVE CVSS lookup, parameter validation.

### Function bug fixes

- **`Convert-Hexadecimal -Hexadecimal`**: hex-to-decimal path was broken. `[Convert]::ToString($Hexadecimal, 10)` coerced the input string to Int32 (base 10) and re-formatted it as base-10 — so `'1098'` returned `'1098'` instead of `'4248'`. Now uses `[Convert]::ToInt64($trimmed, 16)` and strips an optional `0x`/`0X` prefix.
- **`ConvertFrom-IISLog -Path` validation**: previously used `Test-Path -PathType Leaf -Filter "*.log"`; `-Filter` is silently ignored when the path is fully qualified to a single file, so non-`.log` paths passed validation. Now uses `Split-Path -Path $_ -Extension -ieq '.log'`.

Net: **+60 tests**; suite is **854 passed / 2 skipped** locally.

## Test plan

- [x] `./Build/build.ps1 -TaskList Test, Cleanup` passes locally on macOS (PS 7.6.2)
- [ ] CI passes on `ubuntu-latest`