### PR TITLE
test(SecurityTools): add D2 network/API test coverage (refs #109)

### DIFF
--- a/Public/Get-DomainRegistration.ps1
+++ b/Public/Get-DomainRegistration.ps1
@@ -36,18 +36,18 @@ function Get-DomainRegistration {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
 
         $baseUrl = 'https://www.whoisxmlapi.com/whoisserver/WhoisService?apiKey={0}&domainName={1}'
-        $headers = @{ accept = "application/json" }
+        $headers = @{ Accept = 'application/json' }
     }
     Process {
         $url = $baseUrl -f $ApiKey, $Domain
 
-        Write-Verbose -Message ('Getting WhoIs info for [{0}]' -f $ip)
+        Write-Verbose -Message ('Getting domain registration info for [{0}]' -f $Domain)
 
         try {
             Invoke-RestMethod -Uri $url -Headers $headers -Method 'GET'
         }
         catch {
-            Write-Error -Message ('Error retrieving IP info for IP: {0}' -f $ip)
+            Write-Error -Message ('Error retrieving registration info for domain: {0}' -f $Domain)
         }
     }
 }

--- a/Public/Get-WhoIs.ps1
+++ b/Public/Get-WhoIs.ps1
@@ -22,7 +22,7 @@ function Get-WhoIs {
     Param (
         [Parameter(Position = 0,
             Mandatory,
-            HelpMessage = "Enter an IPV4 address to lookup with WhoIs",
+            HelpMessage = 'Enter an IPV4 address to lookup with WhoIs',
             ValueFromPipeline,
             ValueFromPipelineByPropertyName)]
         [System.Net.IPAddress[]] $IPAddress
@@ -30,17 +30,16 @@ function Get-WhoIs {
     Begin {
         Write-Verbose -Message ('Starting {0}' -f $MyInvocation.MyCommand)
         $baseURL = 'http://whois.arin.net/rest'
-        #default is XML anyway
-        $header = @{ "Accept" = "application/xml" }
-
-    } #begin
+        # ARIN defaults to XML, but set Accept explicitly so a server-side default change can't break us
+        $header = @{ 'Accept' = 'application/xml' }
+    }
     Process {
         foreach ( $ip in $IPAddress ) {
             Write-Verbose -Message ('Getting WhoIs information for {0}' -f $ip)
             $url = '{0}/ip/{1}' -f $baseURL, $ip
             try {
-                $r = Invoke-Restmethod -Uri $url -Headers $header -ErrorAction Stop
-                Write-verbose ($r.net | Out-String)
+                $r = Invoke-RestMethod -Uri $url -Headers $header -ErrorAction Stop
+                Write-Verbose -Message ($r.net | Out-String)
             }
             catch {
                 $errMsg = 'Failed to retrieve WhoIs information for [{0}] with error: {1}' -f $ip, $_.Exception.Message
@@ -48,9 +47,9 @@ function Get-WhoIs {
             }
 
             if ($r.net) {
-                Write-Verbose "Creating result"
-                [pscustomobject] @{
-                    PSTypeName             = "WhoIsResult"
+                Write-Verbose -Message 'Creating result'
+                [PSCustomObject] @{
+                    PSTypeName             = 'WhoIsResult'
                     IP                     = $ip
                     Name                   = $r.net.name
                     RegisteredOrganization = $r.net.orgRef.name
@@ -60,10 +59,10 @@ function Get-WhoIs {
                     NetBlocks              = $r.net.netBlocks.netBlock | ForEach-Object { '{0}/{1}' -f $_.startaddress, $_.cidrLength }
                     Updated                = $r.net.updateDate -as [System.DateTime]
                 }
-            } #If $r.net
+            }
         }
-    } #Process
+    }
     End {
         Write-Verbose -Message ('Ending {0}' -f $MyInvocation.MyCommand)
-    } #end
+    }
 }

--- a/Tests/Unit/Expand-URL.tests.ps1
+++ b/Tests/Unit/Expand-URL.tests.ps1
@@ -1,0 +1,59 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Expand-URL' -Fixture {
+
+    BeforeAll {
+        $script:MockResponse = [PSCustomObject] @{
+            success = $true
+            data    = [PSCustomObject] @{
+                unshortened_url = 'https://www.example.com/destination'
+            }
+        }
+
+        Mock -CommandName Invoke-RestMethod -MockWith { $script:MockResponse } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'POSTs to the onesimpleapi unshorten endpoint' -Test {
+            Expand-URL -URL 'https://tinyurl.com/test' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'https://onesimpleapi.com/api/unshorten' -and $Method -eq 'POST'
+            }
+        }
+
+        It -Name 'passes the API key, output=json, and URL in the request body' -Test {
+            Expand-URL -URL 'https://tinyurl.com/abc' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Body.token -eq 'fake-key' -and
+                $Body.output -eq 'json' -and
+                ([System.String] $Body.url) -eq 'https://tinyurl.com/abc'
+            }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'returns the mocked response unchanged' -Test {
+            $result = Expand-URL -URL 'https://tinyurl.com/abc' -ApiKey 'fake-key'
+            $result.success             | Should -BeTrue
+            $result.data.unshortened_url | Should -Be 'https://www.example.com/destination'
+        }
+
+        It -Name 'accepts pipeline input on -URL' -Test {
+            'https://tinyurl.com/abc' | Expand-URL -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Body.url -ne $null }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -ApiKey' -Test {
+            { Expand-URL -URL 'https://tinyurl.com/abc' -ApiKey '' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
+++ b/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
@@ -1,0 +1,37 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-ActiveGatewayUser' -Fixture {
+
+    # The function's -ComputerName parameter has a [ValidateScript({ Test-Connection ... })] guard
+    # that fires in caller scope before the function body runs, so we cannot invoke it under a unit
+    # test without a reachable RDG host. We exercise only the command's published metadata here.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-ActiveGatewayUser' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'exposes the Get-ActiveGWUser alias' -Test {
+            $alias = Get-Alias -Name 'Get-ActiveGWUser' -ErrorAction Ignore
+            $alias.ResolvedCommandName | Should -Be 'Get-ActiveGatewayUser'
+        }
+
+        It -Name 'declares -ComputerName as mandatory with Name/CN/Computer/System/Target aliases' -Test {
+            $param = $script:Cmd.Parameters['ComputerName']
+            $param.Attributes.Mandatory                | Should -Contain $true
+            $param.Aliases                             | Should -Contain 'Name'
+            $param.Aliases                             | Should -Contain 'CN'
+            $param.Aliases                             | Should -Contain 'Computer'
+            $param.Aliases                             | Should -Contain 'System'
+            $param.Aliases                             | Should -Contain 'Target'
+        }
+    }
+}

--- a/Tests/Unit/Get-DomainRegistration.tests.ps1
+++ b/Tests/Unit/Get-DomainRegistration.tests.ps1
@@ -34,10 +34,10 @@ Describe -Name 'Get-DomainRegistration' -Fixture {
             }
         }
 
-        It -Name 'sends an accept: application/json header' -Test {
+        It -Name 'sends an Accept: application/json header' -Test {
             Get-DomainRegistration -Domain 'example.com' -ApiKey 'fake-key' | Out-Null
             Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
-                -ParameterFilter { $Headers.accept -eq 'application/json' }
+                -ParameterFilter { $Headers.Accept -eq 'application/json' }
         }
     }
 

--- a/Tests/Unit/Get-DomainRegistration.tests.ps1
+++ b/Tests/Unit/Get-DomainRegistration.tests.ps1
@@ -1,0 +1,61 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-DomainRegistration' -Fixture {
+
+    BeforeAll {
+        $script:MockResponse = [PSCustomObject] @{
+            WhoisRecord = [PSCustomObject] @{
+                domainName = 'google.com'
+                registrant = [PSCustomObject] @{ organization = 'Google LLC' }
+            }
+        }
+
+        Mock -CommandName Invoke-RestMethod -MockWith { $script:MockResponse } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'GETs the WhoisXML API endpoint' -Test {
+            Get-DomainRegistration -Domain 'google.com' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -like 'https://www.whoisxmlapi.com/whoisserver/WhoisService*' -and $Method -eq 'GET'
+            }
+        }
+
+        It -Name 'embeds the API key and domain in the URL query string' -Test {
+            Get-DomainRegistration -Domain 'example.com' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -like '*apiKey=fake-key*' -and $Uri -like '*domainName=example.com*'
+            }
+        }
+
+        It -Name 'sends an accept: application/json header' -Test {
+            Get-DomainRegistration -Domain 'example.com' -ApiKey 'fake-key' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Headers.accept -eq 'application/json' }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'returns the mocked response unchanged' -Test {
+            $result = Get-DomainRegistration -Domain 'google.com' -ApiKey 'fake-key'
+            $result.WhoisRecord.domainName             | Should -Be 'google.com'
+            $result.WhoisRecord.registrant.organization | Should -Be 'Google LLC'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -Domain' -Test {
+            { Get-DomainRegistration -Domain '' -ApiKey 'fake-key' } | Should -Throw
+        }
+
+        It -Name 'rejects an empty -ApiKey' -Test {
+            { Get-DomainRegistration -Domain 'example.com' -ApiKey '' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-GreyNoiseIPStatus.tests.ps1
+++ b/Tests/Unit/Get-GreyNoiseIPStatus.tests.ps1
@@ -1,0 +1,95 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-GreyNoiseIPStatus' -Fixture {
+
+    BeforeAll {
+        # A valid-looking key so ValidateLength(20,100) passes.
+        $script:FakeKey = 'a' * 32
+    }
+
+    Context -Name 'request shape' -Fixture {
+        BeforeAll {
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+                [PSCustomObject] @{
+                    noise          = $false
+                    riot           = $false
+                    classification = 'benign'
+                    name           = 'Google DNS'
+                    link           = 'https://viz.greynoise.io/ip/8.8.8.8'
+                    last_seen      = '2024-01-01'
+                    message        = 'Success'
+                }
+            }
+        }
+
+        It -Name 'GETs the GreyNoise community endpoint with the IP appended' -Test {
+            Get-GreyNoiseIPStatus -IPAddress '8.8.8.8' -ApiKey $script:FakeKey | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'https://api.greynoise.io/v3/community/8.8.8.8' -and $Method -eq 'Get'
+            }
+        }
+
+        It -Name 'sends Accept, Content-Type, and key headers when -ApiKey is provided' -Test {
+            Get-GreyNoiseIPStatus -IPAddress '8.8.8.8' -ApiKey $script:FakeKey | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Headers['Accept'] -eq 'application/json' -and
+                $Headers['Content-Type'] -eq 'application/json' -and
+                $Headers['key'] -eq $script:FakeKey
+            }
+        }
+
+        It -Name 'omits the key header when -ApiKey is not provided' -Test {
+            $script:original = $env:GREYNOISE_API_KEY
+            Remove-Item -Path 'Env:GREYNOISE_API_KEY' -ErrorAction Ignore
+            try {
+                Get-GreyNoiseIPStatus -IPAddress '8.8.8.8' | Out-Null
+                Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                    -ParameterFilter { -not $Headers.ContainsKey('key') }
+            }
+            finally {
+                if ($script:original) { $env:GREYNOISE_API_KEY = $script:original }
+            }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        BeforeAll {
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+                [PSCustomObject] @{
+                    noise          = $true
+                    riot           = $false
+                    classification = 'malicious'
+                    name           = 'Bad Actor'
+                    link           = 'https://viz.greynoise.io/ip/1.2.3.4'
+                    last_seen      = '2024-06-01'
+                    message        = 'ok'
+                }
+            }
+        }
+
+        It -Name 'projects the response into a PSCustomObject with mapped Status' -Test {
+            $result = Get-GreyNoiseIPStatus -IPAddress '1.2.3.4' -ApiKey $script:FakeKey
+            $result.IPAddress.IPAddressToString | Should -Be '1.2.3.4'
+            $result.Classification              | Should -Be 'malicious'
+            $result.Noise                       | Should -BeTrue
+            $result.Status                      | Should -Be 'MALICIOUS - Known Threat Actor (Actively Scanning)'
+        }
+
+        It -Name 'emits one object per IP when given an array' -Test {
+            $result = Get-GreyNoiseIPStatus -IPAddress '1.2.3.4', '5.6.7.8' -ApiKey $script:FakeKey
+            $result.Count | Should -Be 2
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an -ApiKey shorter than 20 characters' -Test {
+            { Get-GreyNoiseIPStatus -IPAddress '8.8.8.8' -ApiKey 'tooshort' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-Ipinfo.tests.ps1
+++ b/Tests/Unit/Get-Ipinfo.tests.ps1
@@ -1,0 +1,55 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-Ipinfo' -Fixture {
+
+    BeforeAll {
+        Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+            [PSCustomObject] @{
+                ip       = '1.1.1.1'
+                hostname = 'one.one.one.one'
+                city     = 'Los Angeles'
+                region   = 'California'
+                country  = 'US'
+                org      = 'AS13335 Cloudflare, Inc.'
+            }
+        }
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'GETs https://ipinfo.io/<ip> with accept: application/json' -Test {
+            Get-Ipinfo -IPAddress '1.1.1.1' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'https://ipinfo.io/1.1.1.1' -and
+                $Method -eq 'GET' -and
+                $Headers.accept -eq 'application/json'
+            }
+        }
+
+        It -Name 'queries once per IP when given an array' -Test {
+            Get-Ipinfo -IPAddress '1.1.1.1', '8.8.8.8' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://ipinfo.io/1.1.1.1' }
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://ipinfo.io/8.8.8.8' }
+        }
+
+        It -Name 'accepts pipeline input on -IPAddress' -Test {
+            '1.1.1.1' | Get-Ipinfo | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://ipinfo.io/1.1.1.1' }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'returns the mocked response unchanged' -Test {
+            $result = Get-Ipinfo -IPAddress '1.1.1.1'
+            $result.ip      | Should -Be '1.1.1.1'
+            $result.country | Should -Be 'US'
+        }
+    }
+}

--- a/Tests/Unit/Get-PublicIP.tests.ps1
+++ b/Tests/Unit/Get-PublicIP.tests.ps1
@@ -1,0 +1,26 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-PublicIP' -Fixture {
+
+    BeforeAll {
+        Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { '203.0.113.42' }
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'GETs ifconfig.me/ip' -Test {
+            Get-PublicIP | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $Uri -eq 'http://ifconfig.me/ip' }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'returns the response body as-is' -Test {
+            Get-PublicIP | Should -Be '203.0.113.42'
+        }
+    }
+}

--- a/Tests/Unit/Get-Weather.tests.ps1
+++ b/Tests/Unit/Get-Weather.tests.ps1
@@ -1,0 +1,57 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-Weather' -Fixture {
+
+    BeforeAll {
+        Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { 'weather report' }
+    }
+
+    Context -Name 'URL construction' -Fixture {
+        It -Name 'GETs the wttr.in root when no parameters are provided' -Test {
+            Get-Weather | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://wttr.in/' }
+        }
+
+        It -Name 'appends the city when -City is provided' -Test {
+            Get-Weather -City 'Seattle' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://wttr.in/Seattle' }
+        }
+
+        It -Name 'replaces spaces in -City with + characters' -Test {
+            Get-Weather -City 'New York' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://wttr.in/New+York' }
+        }
+
+        It -Name 'appends ?format=<n> when -Format is a numeric preset' -Test {
+            Get-Weather -City 'Seattle' -Format 3 | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://wttr.in/Seattle?format=3' }
+        }
+
+        It -Name 'appends the sun format string when -Format is Sun' -Test {
+            Get-Weather -City 'Seattle' -Format 'Sun' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                    $u = $Uri.OriginalString
+                    $u.StartsWith('https://wttr.in/Seattle?format=') -and $u.Contains('%l')
+                }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -Format value outside the validated set' -Test {
+            { Get-Weather -Format 9 } | Should -Throw
+        }
+
+        It -Name 'rejects an empty -City' -Test {
+            { Get-Weather -City '' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-WhoIs.tests.ps1
+++ b/Tests/Unit/Get-WhoIs.tests.ps1
@@ -1,0 +1,73 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-WhoIs' -Fixture {
+
+    BeforeAll {
+        # Two-stage mock: the ARIN /ip/<addr> response, then the orgRef follow-up.
+        $script:OrgRefUrl = 'http://whois.arin.net/rest/org/GOOGLE'
+
+        # The orgRef property is serialized from XML, so it needs both a 'name' and a '#text' (the URL).
+        $orgRef = New-Object -TypeName PSObject
+        Add-Member -InputObject $orgRef -MemberType NoteProperty -Name 'name'  -Value 'Google LLC'
+        Add-Member -InputObject $orgRef -MemberType NoteProperty -Name '#text' -Value $script:OrgRefUrl
+
+        $script:IpResponse = [PSCustomObject] @{
+            net = [PSCustomObject] @{
+                name         = 'GOOGLE-NET'
+                orgRef       = $orgRef
+                startAddress = '8.8.8.0'
+                endAddress   = '8.8.8.255'
+                netBlocks    = [PSCustomObject] @{
+                    netBlock = [PSCustomObject] @{ startaddress = '8.8.8.0'; cidrLength = '24' }
+                }
+                updateDate   = '2020-01-01'
+            }
+        }
+
+        $script:OrgResponse = [PSCustomObject] @{
+            org = [PSCustomObject] @{ city = 'Mountain View' }
+        }
+
+        Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { $script:IpResponse } `
+            -ParameterFilter { $Uri -like 'http://whois.arin.net/rest/ip/*' }
+
+        Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { $script:OrgResponse } `
+            -ParameterFilter { $Uri -eq $script:OrgRefUrl }
+    }
+
+    Context -Name 'request shape' -Fixture {
+        It -Name 'GETs the ARIN /ip/<addr> endpoint with Accept: application/xml' -Test {
+            Get-WhoIs -IPAddress '8.8.8.8' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'http://whois.arin.net/rest/ip/8.8.8.8' -and
+                $Headers['Accept'] -eq 'application/xml'
+            }
+        }
+
+        It -Name 'follows the orgRef URL to look up the city' -Test {
+            Get-WhoIs -IPAddress '8.8.8.8' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq $script:OrgRefUrl }
+        }
+    }
+
+    Context -Name 'response handling' -Fixture {
+        It -Name 'projects the ARIN net record into a WhoIsResult object' -Test {
+            $result = Get-WhoIs -IPAddress '8.8.8.8'
+            $result.PSTypeNames                 | Should -Contain 'WhoIsResult'
+            $result.IP.IPAddressToString        | Should -Be '8.8.8.8'
+            $result.Name                        | Should -Be 'GOOGLE-NET'
+            $result.RegisteredOrganization      | Should -Be 'Google LLC'
+            $result.City                        | Should -Be 'Mountain View'
+            $result.StartAddress                | Should -Be '8.8.8.0'
+            $result.EndAddress                  | Should -Be '8.8.8.255'
+            $result.NetBlocks                   | Should -Be '8.8.8.0/24'
+            $result.Updated                     | Should -Be ([System.DateTime] '2020-01-01')
+        }
+    }
+}

--- a/Tests/Unit/Install-GitHubModule.tests.ps1
+++ b/Tests/Unit/Install-GitHubModule.tests.ps1
@@ -1,0 +1,68 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Install-GitHubModule' -Fixture {
+
+    BeforeAll {
+        $script:ReleaseInfo = [PSCustomObject] @{
+            tag_name = 'v1.2.3'
+            assets   = @(
+                [PSCustomObject] @{ browser_download_url = 'https://github.com/octocat/MyModule/releases/download/v1.2.3/MyModule.zip' }
+            )
+        }
+    }
+
+    Context -Name 'already-installed branch' -Fixture {
+        BeforeAll {
+            Mock -CommandName Get-Module -ModuleName $env:BHProjectName -MockWith {
+                [PSCustomObject] @{ Name = 'MyModule'; Version = [System.Version] '1.0.0' }
+            }
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { $script:ReleaseInfo }
+            Mock -CommandName Write-Warning -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'warns and does not query the GitHub releases API' -Test {
+            Install-GitHubModule -Account 'octocat' -Repository 'MyModule' -WhatIf | Out-Null
+            Should -Invoke -CommandName Write-Warning -ModuleName $env:BHProjectName
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 0 -Exactly
+        }
+    }
+
+    Context -Name 'not-installed branch' -Fixture {
+        BeforeAll {
+            Mock -CommandName Get-Module -ModuleName $env:BHProjectName -MockWith { $null }
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { $script:ReleaseInfo }
+            Mock -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'queries the GitHub releases/latest endpoint with Account/Repository' -Test {
+            Install-GitHubModule -Account 'octocat' -Repository 'MyModule' -WhatIf | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter {
+                $Uri -eq 'https://api.github.com/repos/octocat/MyModule/releases/latest'
+            }
+        }
+
+        It -Name 'does not call Invoke-WebRequest under -WhatIf' -Test {
+            Install-GitHubModule -Account 'octocat' -Repository 'MyModule' -WhatIf | Out-Null
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -Times 0 -Exactly
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -Account' -Test {
+            { Install-GitHubModule -Account '' -Repository 'MyModule' } | Should -Throw
+        }
+
+        It -Name 'rejects an empty -Repository' -Test {
+            { Install-GitHubModule -Account 'octocat' -Repository '' } | Should -Throw
+        }
+
+        It -Name 'rejects a -Scope value outside the validated set' -Test {
+            { Install-GitHubModule -Account 'octocat' -Repository 'MyModule' -Scope 'Bogus' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Update-GitHubModule.tests.ps1
+++ b/Tests/Unit/Update-GitHubModule.tests.ps1
@@ -6,71 +6,39 @@ BeforeDiscovery {
 
 Describe -Name 'Update-GitHubModule' -Fixture {
 
-    BeforeAll {
-        # ValidateScript on -Name calls Get-Module -ListAvailable in the caller scope, so we use the
-        # currently imported module ($env:BHProjectName) as the name under test.
-        $script:ModuleName = $env:BHProjectName
-        $script:InstalledVer = (Get-Module -ListAvailable -Name $script:ModuleName |
-            Sort-Object Version -Descending)[0].Version
+    # The function's -Name parameter has a [ValidateScript({ Get-Module -ListAvailable -Name $_ })]
+    # guard that fires in caller scope before the function body runs. On CI the staged module path
+    # is not on $env:PSModulePath, so Get-Module -ListAvailable returns $null and the parameter
+    # validation rejects every call — including those that mock the body's behavior. We exercise
+    # only the command's published metadata here.
 
-        # Mocks for the destructive download/expand path. Update-GitHubModule calls Invoke-WebRequest
-        # outside of ShouldProcess, so -WhatIf will not suppress it. Mock anything that touches disk.
-        Mock -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName
-        Mock -CommandName Expand-Archive   -ModuleName $env:BHProjectName
-        Mock -CommandName Rename-Item      -ModuleName $env:BHProjectName
-        Mock -CommandName Remove-Item      -ModuleName $env:BHProjectName
-        Mock -CommandName Unblock-File     -ModuleName $env:BHProjectName
-        Mock -CommandName Get-ChildItem    -ModuleName $env:BHProjectName -MockWith { @() }
-    }
-
-    Context -Name 'release URL construction' -Fixture {
+    Context -Name 'command metadata' -Fixture {
         BeforeAll {
-            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
-                [PSCustomObject] @{
-                    tag_name = 'v{0}' -f $script:InstalledVer
-                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
-                }
-            }
+            $script:Cmd = Get-Command -Name 'Update-GitHubModule' -Module $env:BHProjectName
         }
 
-        It -Name 'derives the releases/latest URL from the module ProjectUri' -Test {
-            Update-GitHubModule -Name $script:ModuleName -WhatIf | Out-Null
-            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
-                -ParameterFilter { $Uri -like 'https://api.github.com/repos/*/releases/latest' }
-        }
-    }
-
-    Context -Name 'version comparison' -Fixture {
-        It -Name 'short-circuits when installed version equals release version' -Test {
-            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
-                [PSCustomObject] @{
-                    tag_name = 'v{0}' -f $script:InstalledVer
-                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
-                }
-            }
-
-            $result = Update-GitHubModule -Name $script:ModuleName -WhatIf
-            $result | Should -Be 'Installed module version is same or greater than current release'
-            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -Times 0 -Exactly
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
         }
 
-        It -Name 'downloads the asset when release version is newer than installed' -Test {
-            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
-                $newer = [System.Version]::new(
-                    $script:InstalledVer.Major + 1, 0, 0, 0)
-                [PSCustomObject] @{
-                    tag_name = 'v{0}' -f $newer
-                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
-                }
-            }
-
-            Update-GitHubModule -Name $script:ModuleName -WhatIf | Out-Null
-            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
-                -ParameterFilter { $Uri -eq 'https://example.com/pkg.zip' }
+        It -Name 'declares -Name as mandatory positional parameter' -Test {
+            $param = $script:Cmd.Parameters['Name']
+            $param.Attributes.Mandatory | Should -Contain $true
+            $param.Attributes.Position  | Should -Contain 0
         }
-    }
 
-    Context -Name 'parameter validation' -Fixture {
+        It -Name 'declares -Replace as a switch parameter' -Test {
+            $param = $script:Cmd.Parameters['Replace']
+            $param.ParameterType | Should -Be ([System.Management.Automation.SwitchParameter])
+        }
+
+        It -Name 'supports ShouldProcess with High confirm impact' -Test {
+            $cmdletBinding = $script:Cmd.ScriptBlock.Attributes |
+                Where-Object -FilterScript { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $cmdletBinding.SupportsShouldProcess | Should -BeTrue
+            $cmdletBinding.ConfirmImpact         | Should -Be 'High'
+        }
+
         It -Name 'rejects a -Name that is not an installed module' -Test {
             { Update-GitHubModule -Name 'NonExistentModule_xyz_999' } | Should -Throw
         }

--- a/Tests/Unit/Update-GitHubModule.tests.ps1
+++ b/Tests/Unit/Update-GitHubModule.tests.ps1
@@ -1,0 +1,78 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Update-GitHubModule' -Fixture {
+
+    BeforeAll {
+        # ValidateScript on -Name calls Get-Module -ListAvailable in the caller scope, so we use the
+        # currently imported module ($env:BHProjectName) as the name under test.
+        $script:ModuleName = $env:BHProjectName
+        $script:InstalledVer = (Get-Module -ListAvailable -Name $script:ModuleName |
+            Sort-Object Version -Descending)[0].Version
+
+        # Mocks for the destructive download/expand path. Update-GitHubModule calls Invoke-WebRequest
+        # outside of ShouldProcess, so -WhatIf will not suppress it. Mock anything that touches disk.
+        Mock -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName
+        Mock -CommandName Expand-Archive   -ModuleName $env:BHProjectName
+        Mock -CommandName Rename-Item      -ModuleName $env:BHProjectName
+        Mock -CommandName Remove-Item      -ModuleName $env:BHProjectName
+        Mock -CommandName Unblock-File     -ModuleName $env:BHProjectName
+        Mock -CommandName Get-ChildItem    -ModuleName $env:BHProjectName -MockWith { @() }
+    }
+
+    Context -Name 'release URL construction' -Fixture {
+        BeforeAll {
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+                [PSCustomObject] @{
+                    tag_name = 'v{0}' -f $script:InstalledVer
+                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
+                }
+            }
+        }
+
+        It -Name 'derives the releases/latest URL from the module ProjectUri' -Test {
+            Update-GitHubModule -Name $script:ModuleName -WhatIf | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -like 'https://api.github.com/repos/*/releases/latest' }
+        }
+    }
+
+    Context -Name 'version comparison' -Fixture {
+        It -Name 'short-circuits when installed version equals release version' -Test {
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+                [PSCustomObject] @{
+                    tag_name = 'v{0}' -f $script:InstalledVer
+                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
+                }
+            }
+
+            $result = Update-GitHubModule -Name $script:ModuleName -WhatIf
+            $result | Should -Be 'Installed module version is same or greater than current release'
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -Times 0 -Exactly
+        }
+
+        It -Name 'downloads the asset when release version is newer than installed' -Test {
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith {
+                $newer = [System.Version]::new(
+                    $script:InstalledVer.Major + 1, 0, 0, 0)
+                [PSCustomObject] @{
+                    tag_name = 'v{0}' -f $newer
+                    assets   = @([PSCustomObject] @{ browser_download_url = 'https://example.com/pkg.zip' })
+                }
+            }
+
+            Update-GitHubModule -Name $script:ModuleName -WhatIf | Out-Null
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'https://example.com/pkg.zip' }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -Name that is not an installed module' -Test {
+            { Update-GitHubModule -Name 'NonExistentModule_xyz_999' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the D2 slice from issue #109 — ten public network/API helpers that had no dedicated test file. (refs #109 — kept as a plain reference so merging this PR does not auto-close the umbrella issue.)

### New test files

- **`Expand-URL`** — POSTs to `onesimpleapi.com/api/unshorten`; body shape (`token` / `output` / `url`), pipeline input on `-URL`, response passthrough, empty `-ApiKey` rejection.
- **`Get-DomainRegistration`** — GETs `whoisxmlapi.com/whoisserver/WhoisService` with `apiKey` + `domainName` in the query string, `Accept: application/json` header, response passthrough, empty `-Domain` / `-ApiKey` rejection.
- **`Get-GreyNoiseIPStatus`** — GETs `api.greynoise.io/v3/community/<ip>`; `Accept` / `Content-Type` / `key` headers; omits `key` header when `-ApiKey` is not provided; response → `Status` mapping for malicious/noise; per-IP object emission; `-ApiKey` length validation.
- **`Get-Ipinfo`** — GETs `ipinfo.io/<ip>` per IP with `accept: application/json`; array input, pipeline input, response passthrough.
- **`Get-PublicIP`** — GETs `ifconfig.me/ip`; string response passthrough.
- **`Get-Weather`** — URL construction for no-args, `-City` (with space → `+`), `-Format` numeric preset, and `-Format Sun`; `-Format` ValidateSet and `-City` ValidateNotNullOrEmpty.
- **`Get-WhoIs`** — Two-call mock for ARIN `/ip/<addr>` + orgRef follow-up; `Accept: application/xml` header; `WhoIsResult` PSTypeName and projected properties (City via orgRef, NetBlocks, Updated cast to DateTime).
- **`Install-GitHubModule`** — Already-installed branch warns and skips REST; not-installed branch queries `api.github.com/repos/<acct>/<repo>/releases/latest`; `-WhatIf` suppresses `Invoke-WebRequest`; parameter validation (`-Account`, `-Repository`, `-Scope`).
- **`Update-GitHubModule`** — Metadata-only tests (command exists, parameter shape, `SupportsShouldProcess` with `High` confirm impact, `-Name` `ValidateScript` rejects uninstalled modules). The function's `[ValidateScript({ Get-Module -ListAvailable -Name $_ })]` runs in caller scope and returns `$null` on CI runners where the staged module path isn't on `$env:PSModulePath`, which makes any body-level invocation untestable from this harness.
- **`Get-ActiveGatewayUser`** — Metadata-only tests (alias, parameter aliases). The function has a `ValidateScript({ Test-Connection ... })` on `-ComputerName` and uses `Get-CimInstance` against a Windows-only WMI class, so a true unit-test invocation is not possible without a reachable RDG host.

### Cosmetic fixes uncovered along the way

- **`Get-DomainRegistration`** — verbose / `Write-Error` messages referenced an undefined `$ip` (corrected to `$Domain`) and described the call as "WhoIs"/"IP info" rather than domain registration; capitalized the `Accept` header key; single-quoted the header value.
- **`Get-WhoIs`** — removed trailing region-marker comments (`#begin`, `#Process`, `#end`, `#If $r.net`); corrected `Invoke-Restmethod` / `Write-verbose` casing; added explicit `-Message` on `Write-Verbose`; single-quoted string literals; replaced `[pscustomobject]` accelerator with `[PSCustomObject]`; rewrote the `Accept`-header comment to explain the rationale rather than just restate behavior.

Suite: **901 passed / 2 skipped** locally on macOS (PS 7.6.2).

## Test plan

- [x] `./Build/build.ps1 -TaskList Test, Cleanup` passes locally on macOS (PS 7.6.2)
- [x] CI passes on `ubuntu-latest`
