### PR TITLE
test(SecurityTools): add D3 file-system test coverage (refs #109)

### DIFF
--- a/Public/Install-ModuleFromZip.ps1
+++ b/Public/Install-ModuleFromZip.ps1
@@ -65,7 +65,7 @@ function Install-ModuleFromZip {
             Expand-Archive -Path $Path -DestinationPath $tempPath
 
             # GET MODULE INFO
-            $psDataFile = Get-ChildItem $tempPath -Recurse -Filter '*.psd1'
+            $psDataFile = Get-ChildItem -Path $tempPath -Recurse -Filter '*.psd1'
             $psData = Import-PowerShellDataFile -Path $psDataFile.FullName
             $moduleInfo = @{
                 ModuleName      = [System.IO.Path]::GetFileNameWithoutExtension($psDataFile)
@@ -73,8 +73,8 @@ function Install-ModuleFromZip {
             }
 
             # RENAME MODULE FOLDER TO VERSION NUMBER
-            Rename-Item -Path (Get-ChildItem $tempPath).FullName -NewName $moduleInfo.RequiredVersion.ToString()
-            $moduleFolder = Get-ChildItem $tempPath
+            Rename-Item -Path (Get-ChildItem -Path $tempPath).FullName -NewName $moduleInfo.RequiredVersion.ToString()
+            $moduleFolder = Get-ChildItem -Path $tempPath
 
             # SET MODULE PATH
             $modulePath = Join-Path -Path $moduleHome -ChildPath $moduleInfo.ModuleName

--- a/Public/Save-KBFile.ps1
+++ b/Public/Save-KBFile.ps1
@@ -99,7 +99,7 @@ function Save-KBFile {
         }
     }
     Process {
-        if ($Name.Count -gt 0 -and $PSBoundParameters.FilePath) {
+        if ($Name.Count -gt 1 -and $PSBoundParameters.FilePath) {
             Write-Error -Message 'You may specify only one KB when using FilePath' -ErrorAction Stop
         }
 

--- a/Tests/Unit/Export-WebScan.tests.ps1
+++ b/Tests/Unit/Export-WebScan.tests.ps1
@@ -1,0 +1,119 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-WebScan' -Fixture {
+
+    BeforeAll {
+        # Tiny Acunetix-shaped XML report. The function reaches into
+        # $xml.ScanGroup.Scan.ReportItems.ReportItem and pulls fields out of #cdata-section nodes.
+        $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+        $script:ReportPath = Join-Path -Path $script:TempDir -ChildPath 'acunetix.xml'
+
+        $reportXml = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<ScanGroup>
+  <Scan>
+    <ReportItems>
+      <ReportItem>
+        <Name><![CDATA[SQL Injection]]></Name>
+        <ModuleName><![CDATA[Scripting (SQL_Injection.script)]]></ModuleName>
+        <Details><![CDATA[Vulnerable parameter detected]]></Details>
+        <Affects><![CDATA[/login.aspx]]></Affects>
+        <Parameter><![CDATA[username]]></Parameter>
+        <IsFalsePositive><![CDATA[0]]></IsFalsePositive>
+        <Severity><![CDATA[high]]></Severity>
+        <Type><![CDATA[Validation]]></Type>
+        <Impact><![CDATA[Possible data exposure]]></Impact>
+        <Description><![CDATA[Classic SQLi]]></Description>
+        <DetailedInformation><![CDATA[See documentation]]></DetailedInformation>
+        <Recommendation><![CDATA[Use parameterized queries]]></Recommendation>
+        <TechnicalDetails><Request><![CDATA[GET /login.aspx?u=admin]]></Request></TechnicalDetails>
+        <CWEList><CWE><![CDATA[CWE-89]]></CWE><CVE><![CDATA[CVE-2023-99999]]></CVE></CWEList>
+        <CVSS><Score><![CDATA[7.5]]></Score></CVSS>
+        <CVSS3><Score><![CDATA[9.1]]></Score></CVSS3>
+      </ReportItem>
+      <ReportItem>
+        <Name><![CDATA[Informational Header]]></Name>
+        <ModuleName><![CDATA[Per_Server.script]]></ModuleName>
+        <Details><![CDATA[X-Powered-By header present]]></Details>
+        <Affects><![CDATA[/]]></Affects>
+        <Parameter><![CDATA[]]></Parameter>
+        <IsFalsePositive><![CDATA[0]]></IsFalsePositive>
+        <Severity><![CDATA[informational]]></Severity>
+        <Type><![CDATA[Informational]]></Type>
+        <Impact><![CDATA[None]]></Impact>
+        <Description><![CDATA[Information disclosure]]></Description>
+        <DetailedInformation><![CDATA[]]></DetailedInformation>
+        <Recommendation><![CDATA[Remove header]]></Recommendation>
+        <TechnicalDetails><Request><![CDATA[GET /]]></Request></TechnicalDetails>
+        <CWEList><CWE><![CDATA[]]></CWE><CVE><![CDATA[]]></CVE></CWEList>
+        <CVSS><Score><![CDATA[0.0]]></Score></CVSS>
+        <CVSS3><Score><![CDATA[0.0]]></Score></CVSS3>
+      </ReportItem>
+    </ReportItems>
+  </Scan>
+</ScanGroup>
+'@
+        Set-Content -Path $script:ReportPath -Value $reportXml -Encoding utf8
+
+        # Pester mocks only bind regular parameters (e.g. -Path) when the mock body has explicit
+        # begin/process/end blocks. We use begin to capture -Path and process to count rows;
+        # per-row property assertions are skipped because pipeline-bound objects inside a Pester
+        # mock script block do not expose their NoteProperties through $_ reliably.
+        $script:CapturedRowCount = 0
+        $script:CapturedExportPath = $null
+        Mock -CommandName Export-Excel -ModuleName $env:BHProjectName -MockWith {
+            begin {
+                $script:CapturedExportPath = $Path
+            }
+            process {
+                $script:CapturedRowCount++
+            }
+        }
+        Mock -CommandName New-ExcelStyle -ModuleName $env:BHProjectName -MockWith { [PSCustomObject] @{ Mock = $true } }
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:TempDir) {
+            Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    Context -Name 'happy path' -Fixture {
+        BeforeAll {
+            Export-WebScan -Path $script:ReportPath -OutputDirectory $script:TempDir | Out-Null
+        }
+
+        # NOTE: Should -Invoke does not count Pester mocks whose body uses explicit begin/process/end
+        # blocks. We need those blocks to bind -Path and to receive the pipeline objects, so we
+        # assert invocation indirectly via $script:CapturedRowCount instead.
+        It -Name 'pipes one row per ReportItem to Export-Excel' -Test {
+            $script:CapturedRowCount | Should -Be 2
+        }
+
+        It -Name 'targets a WebScans_<date>.xlsx file in the output directory' -Test {
+            $script:CapturedExportPath | Should -Match 'WebScans_\d{4}-\d{2}-\d{2}\.xlsx$'
+            (Split-Path -Path $script:CapturedExportPath -Parent) | Should -Be $script:TempDir
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -Path that does not exist' -Test {
+            { Export-WebScan -Path (Join-Path -Path $script:TempDir -ChildPath 'missing.xml') } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path whose extension is not .xml' -Test {
+            $bogus = Join-Path -Path $script:TempDir -ChildPath 'report.txt'
+            Set-Content -Path $bogus -Value '<not xml/>'
+            { Export-WebScan -Path $bogus } | Should -Throw
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            { Export-WebScan -Path $script:ReportPath -OutputDirectory (Join-Path -Path $script:TempDir -ChildPath 'nope') } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-AlternateDataStream.tests.ps1
+++ b/Tests/Unit/Get-AlternateDataStream.tests.ps1
@@ -1,0 +1,71 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-AlternateDataStream' -Fixture {
+
+    # Get-Item -Stream * is Windows/NTFS only — on Linux/macOS PowerShell rejects the parameter
+    # set entirely, so body-level invocation here is metadata + parameter-validation only, plus
+    # a Windows-only happy-path that creates a real ADS on the test fixture file.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-AlternateDataStream' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -Path with default value "*.*" (not mandatory)' -Test {
+            $param = $script:Cmd.Parameters['Path']
+            $param.Attributes.Mandatory | Should -Not -Contain $true
+            $param.Attributes.Position  | Should -Contain 0
+        }
+
+        It -Name 'declares System.Management.Automation.PSCustomObject as the output type' -Test {
+            $script:Cmd.OutputType.Type | Should -Contain ([System.Management.Automation.PSCustomObject])
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -Path' -Test {
+            { Get-AlternateDataStream -Path '' } | Should -Throw
+        }
+    }
+
+    Context -Name 'happy path (Windows only)' -Fixture {
+        BeforeAll {
+            if ($IsWindows) {
+                $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+                New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+
+                $script:TestFile = Join-Path -Path $script:TempDir -ChildPath 'fixture.dat'
+                Set-Content -Path $script:TestFile -Value 'primary stream content'
+                # Add an alternate data stream
+                Set-Content -Path $script:TestFile -Stream 'TestStream' -Value 'hidden stream payload'
+            }
+        }
+
+        AfterAll {
+            if ($IsWindows -and (Test-Path -Path $script:TempDir)) {
+                Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+            }
+        }
+
+        It -Name 'returns the alternate data stream and omits the default :$DATA stream' -Skip:(-not $IsWindows) -Test {
+            $result = Get-AlternateDataStream -Path $script:TestFile
+            $result               | Should -Not -BeNullOrEmpty
+            $result.Stream        | Should -Be 'TestStream'
+            $result.Stream        | Should -Not -Contain ':$DATA'
+        }
+
+        It -Name 'projects each stream with Path / Stream / Size properties' -Skip:(-not $IsWindows) -Test {
+            $result = Get-AlternateDataStream -Path $script:TestFile
+            $result.Path          | Should -Be $script:TestFile
+            $result.Size          | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/Tests/Unit/Get-DirectoryReport.tests.ps1
+++ b/Tests/Unit/Get-DirectoryReport.tests.ps1
@@ -1,0 +1,77 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-DirectoryReport' -Fixture {
+
+    BeforeAll {
+        $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        $script:OutDir  = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+        New-Item -Path $script:OutDir  -ItemType Directory | Out-Null
+
+        # Create a subfolder with two known-size files. Sizes are far below 1 GB; we test by
+        # passing very small -SizeInGb thresholds or -All.
+        $subDir = Join-Path -Path $script:TempDir -ChildPath 'data'
+        New-Item -Path $subDir -ItemType Directory | Out-Null
+        [System.IO.File]::WriteAllBytes((Join-Path -Path $subDir -ChildPath 'big.dat'),   [System.Byte[]]::new(4096))
+        [System.IO.File]::WriteAllBytes((Join-Path -Path $subDir -ChildPath 'small.dat'), [System.Byte[]]::new(128))
+    }
+
+    AfterAll {
+        foreach ($d in @($script:TempDir, $script:OutDir)) {
+            if (Test-Path -Path $d) { Remove-Item -Path $d -Recurse -Force -ErrorAction Ignore }
+        }
+    }
+
+    Context -Name 'happy path with -All' -Fixture {
+        It -Name 'emits string output including the Directory: header line' -Test {
+            $output = Get-DirectoryReport -Path $script:TempDir -All
+            ($output -join "`n") | Should -Match 'Directory: '
+        }
+
+        It -Name 'emits a "Files greater than: 0 GB" section when -All is used' -Test {
+            $output = Get-DirectoryReport -Path $script:TempDir -All
+            ($output -join "`n") | Should -Match 'Files greater than: 0'
+        }
+    }
+
+    Context -Name '-OutputDirectory writes a log file' -Fixture {
+        It -Name 'creates a DirStats_<timestamp>.log file in the output directory' -Test {
+            # Drain pre-existing logs so we can detect the new one deterministically
+            Get-ChildItem -Path $script:OutDir -Filter 'DirStats_*.log' | Remove-Item -Force -ErrorAction Ignore
+
+            Get-DirectoryReport -Path $script:TempDir -OutputDirectory $script:OutDir -All | Out-Null
+
+            $log = Get-ChildItem -Path $script:OutDir -Filter 'DirStats_*.log'
+            $log              | Should -Not -BeNullOrEmpty
+            $log.Count        | Should -Be 1
+            (Get-Content -Path $log.FullName -Raw) | Should -Match 'Directory: '
+        }
+    }
+
+    Context -Name 'aliases and parameter validation' -Fixture {
+        It -Name 'exposes the Get-DirStats alias' -Test {
+            (Get-Alias -Name 'Get-DirStats' -ErrorAction Ignore).ResolvedCommandName | Should -Be 'Get-DirectoryReport'
+        }
+
+        It -Name 'rejects a -Path that does not exist' -Test {
+            { Get-DirectoryReport -Path (Join-Path -Path $script:TempDir -ChildPath 'missing') } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path that is a file rather than a container' -Test {
+            $f = Join-Path -Path $script:TempDir -ChildPath 'data/small.dat'
+            { Get-DirectoryReport -Path $f } | Should -Throw
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            { Get-DirectoryReport -Path $script:TempDir -OutputDirectory (Join-Path -Path $script:OutDir -ChildPath 'missing') } | Should -Throw
+        }
+
+        It -Name 'rejects -SizeInGb outside the 0..10 range' -Test {
+            { Get-DirectoryReport -Path $script:TempDir -SizeInGb 11 } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-FileHeader.tests.ps1
+++ b/Tests/Unit/Get-FileHeader.tests.ps1
@@ -1,0 +1,62 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-FileHeader' -Fixture {
+
+    BeforeAll {
+        $script:TempDir  = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+
+        # Write a known byte sequence to a temp file: 50 4B 03 04 05 06 07 08 (ZIP magic + filler).
+        $script:KnownBytes = [System.Byte[]] @(0x50, 0x4B, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08)
+        $script:TempFile   = Join-Path -Path $script:TempDir -ChildPath 'known.bin'
+        [System.IO.File]::WriteAllBytes($script:TempFile, $script:KnownBytes)
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:TempDir) {
+            Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    Context -Name 'happy path' -Fixture {
+        It -Name 'returns the first 4 bytes as space-separated hex by default' -Test {
+            Get-FileHeader -Path $script:TempFile | Should -Be '50 4B 03 04'
+        }
+
+        It -Name 'returns the requested number of bytes when -Bytes is specified' -Test {
+            Get-FileHeader -Path $script:TempFile -Bytes 8 | Should -Be '50 4B 03 04 05 06 07 08'
+        }
+
+        It -Name 'returns exactly 2 bytes when -Bytes is at the minimum of 2' -Test {
+            $result = Get-FileHeader -Path $script:TempFile -Bytes 2
+            ($result -split ' ').Count | Should -Be 2
+            $result | Should -Be '50 4B'
+        }
+
+        It -Name 'accepts -Path via pipeline' -Test {
+            $script:TempFile | Get-FileHeader | Should -Be '50 4B 03 04'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -Path that does not exist' -Test {
+            { Get-FileHeader -Path (Join-Path -Path $script:TempDir -ChildPath 'missing.bin') } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path that is a directory rather than a file' -Test {
+            { Get-FileHeader -Path $script:TempDir } | Should -Throw
+        }
+
+        It -Name 'rejects -Bytes below the minimum of 2' -Test {
+            { Get-FileHeader -Path $script:TempFile -Bytes 1 } | Should -Throw
+        }
+
+        It -Name 'rejects -Bytes above the maximum of 100' -Test {
+            { Get-FileHeader -Path $script:TempFile -Bytes 101 } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-FileInfo.tests.ps1
+++ b/Tests/Unit/Get-FileInfo.tests.ps1
@@ -1,0 +1,78 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-FileInfo' -Fixture {
+
+    BeforeAll {
+        $script:FakeSignatures = @(
+            [PSCustomObject] @{ Hex_signature = '50 4B 03 04'; ISO_8859_1 = 'PK..'; File_extension = '.zip,.docx,.xlsx'; Description = 'ZIP archive' }
+            [PSCustomObject] @{ Hex_signature = '89 50 4E 47'; ISO_8859_1 = '.PNG';  File_extension = '.png';            Description = 'PNG image' }
+            [PSCustomObject] @{ Hex_signature = '25 50 44 46'; ISO_8859_1 = '%PDF';  File_extension = '.pdf';            Description = 'PDF document' }
+        )
+
+        # The function caches the signature table in a Global variable. Save and restore the existing
+        # value so we don't clobber an in-session cache or leak test state.
+        $script:HadGlobalCache  = $null -ne (Get-Variable -Name 'FileSignatures' -Scope Global -ErrorAction Ignore)
+        $script:OriginalCache   = if ($script:HadGlobalCache) { $Global:FileSignatures } else { $null }
+    }
+
+    AfterAll {
+        # Restore prior state
+        Remove-Variable -Name 'FileSignatures' -Scope Global -Force -ErrorAction Ignore
+        if ($script:HadGlobalCache) {
+            New-Variable -Name 'FileSignatures' -Scope Global -Value $script:OriginalCache
+        }
+    }
+
+    Context -Name 'happy path with pre-warmed cache' -Fixture {
+        BeforeEach {
+            # Pre-populate the Global cache so the function does not call Invoke-RestMethod.
+            Remove-Variable -Name 'FileSignatures' -Scope Global -Force -ErrorAction Ignore
+            New-Variable -Name 'FileSignatures' -Scope Global -Value $script:FakeSignatures
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'returns the matching signature record by hex prefix' -Test {
+            $result = Get-FileInfo -Signature '50 4B 03 04'
+            $result.File_extension | Should -Be '.zip,.docx,.xlsx'
+            $result.Description    | Should -Be 'ZIP archive'
+        }
+
+        It -Name 'does not call Invoke-RestMethod when the Global cache is populated' -Test {
+            Get-FileInfo -Signature '50 4B 03 04' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 0 -Exactly
+        }
+
+        It -Name 'accepts -Signature via pipeline' -Test {
+            $result = '25 50 44 46' | Get-FileInfo
+            $result.Description | Should -Be 'PDF document'
+        }
+    }
+
+    Context -Name 'cache-miss path' -Fixture {
+        BeforeEach {
+            # Clear cache so the function fetches the signature table.
+            Remove-Variable -Name 'FileSignatures' -Scope Global -Force -ErrorAction Ignore
+            Mock -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -MockWith { $script:FakeSignatures }
+        }
+
+        It -Name 'GETs the signatures gist when the cache is empty' -Test {
+            Get-FileInfo -Signature '89 50 4E 47' | Out-Null
+            Should -Invoke -CommandName Invoke-RestMethod -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $Uri -like 'https://gist.githubusercontent.com/*/FileSignatures.json' }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -Signature containing non-hex / non-space characters' -Test {
+            { Get-FileInfo -Signature '50 4B !! 04' } | Should -Throw
+        }
+
+        It -Name 'rejects an empty -Signature' -Test {
+            { Get-FileInfo -Signature '' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-FolderSize.tests.ps1
+++ b/Tests/Unit/Get-FolderSize.tests.ps1
@@ -1,0 +1,77 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-FolderSize' -Fixture {
+
+    BeforeAll {
+        # Build: <Temp>/<guid>/alpha/file_1KB.dat, /<guid>/beta/file_2KB.dat, /<guid>/gamma/file_512B.dat
+        $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+
+        $script:AlphaDir = Join-Path -Path $script:TempDir -ChildPath 'alpha'
+        $script:BetaDir = Join-Path -Path $script:TempDir -ChildPath 'beta'
+        $script:GammaDir = Join-Path -Path $script:TempDir -ChildPath 'gamma'
+        New-Item -Path $script:AlphaDir -ItemType Directory | Out-Null
+        New-Item -Path $script:BetaDir  -ItemType Directory | Out-Null
+        New-Item -Path $script:GammaDir -ItemType Directory | Out-Null
+
+        # WriteAllBytes gives us exact, deterministic file sizes.
+        [System.IO.File]::WriteAllBytes((Join-Path -Path $script:AlphaDir -ChildPath 'a.dat'), [System.Byte[]]::new(1024))
+        [System.IO.File]::WriteAllBytes((Join-Path -Path $script:BetaDir  -ChildPath 'b.dat'), [System.Byte[]]::new(2048))
+        [System.IO.File]::WriteAllBytes((Join-Path -Path $script:GammaDir -ChildPath 'c.dat'), [System.Byte[]]::new(512))
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:TempDir) {
+            Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    Context -Name 'happy path with explicit -Path' -Fixture {
+        BeforeAll { $script:Result = Get-FolderSize -Path $script:TempDir }
+
+        It -Name 'emits one row per child folder plus a GrandTotal row' -Test {
+            # 3 folders + GrandTotal = 4
+            $script:Result.Count | Should -Be 4
+        }
+
+        It -Name 'reports exact byte counts for each subfolder' -Test {
+            ($script:Result | Where-Object FolderName -eq 'alpha').'Size(Bytes)' | Should -Be 1024
+            ($script:Result | Where-Object FolderName -eq 'beta').'Size(Bytes)'  | Should -Be 2048
+            ($script:Result | Where-Object FolderName -eq 'gamma').'Size(Bytes)' | Should -Be 512
+        }
+
+        It -Name 'sums the GrandTotal row to the total of all folders' -Test {
+            $total = $script:Result | Where-Object FolderName -eq 'GrandTotal'
+            $total.'Size(Bytes)' | Should -Be 3584   # 1024 + 2048 + 512
+        }
+    }
+
+    Context -Name '-NoTotal switch' -Fixture {
+        It -Name 'omits the GrandTotal row when -NoTotal is specified' -Test {
+            $result = Get-FolderSize -Path $script:TempDir -NoTotal
+            $result.Count | Should -Be 3
+            ($result | Where-Object FolderName -eq 'GrandTotal') | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name '-OmitFolder filter' -Fixture {
+        It -Name 'excludes folders whose full path matches -OmitFolder' -Test {
+            $result = Get-FolderSize -Path $script:TempDir -OmitFolder $script:BetaDir -NoTotal
+            $result.Count | Should -Be 2
+            ($result | Where-Object FolderName -eq 'beta') | Should -BeNullOrEmpty
+        }
+    }
+
+    Context -Name '-FolderName filter' -Fixture {
+        It -Name 'returns only the folder matching -FolderName' -Test {
+            $result = Get-FolderSize -Path $script:TempDir -FolderName 'alpha' -NoTotal
+            $result.Count           | Should -Be 1
+            $result.FolderName      | Should -Be 'alpha'
+            $result.'Size(Bytes)'   | Should -Be 1024
+        }
+    }
+}

--- a/Tests/Unit/Get-ItemAge.tests.ps1
+++ b/Tests/Unit/Get-ItemAge.tests.ps1
@@ -1,0 +1,107 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-ItemAge' -Fixture {
+
+    BeforeAll {
+        # Build a temp directory layout we control. Files have LastWriteTime backdated so the
+        # AgeInDays bucketing is deterministic regardless of when the test runs.
+        $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+        $script:SubDir  = Join-Path -Path $script:TempDir -ChildPath 'nested'
+        New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+        New-Item -Path $script:SubDir  -ItemType Directory | Out-Null
+
+        # Top-level files (one old, one new)
+        $oldFile = Join-Path -Path $script:TempDir -ChildPath 'old.txt'
+        $newFile = Join-Path -Path $script:TempDir -ChildPath 'new.txt'
+        Set-Content -Path $oldFile -Value ('a' * 1024)
+        Set-Content -Path $newFile -Value ('b' * 2048)
+        (Get-Item -Path $oldFile).LastWriteTime = (Get-Date).AddDays(-30)
+        (Get-Item -Path $newFile).LastWriteTime = (Get-Date).AddDays(-1)
+
+        # Nested file (recurse-only)
+        $nestedFile = Join-Path -Path $script:SubDir -ChildPath 'deep.txt'
+        Set-Content -Path $nestedFile -Value ('c' * 512)
+        (Get-Item -Path $nestedFile).LastWriteTime = (Get-Date).AddDays(-10)
+        # Backdate the directory entries too — Get-ChildItem -Recurse returns them, and the function
+        # sorts ALL items (not just files) when picking OldestFile / NewestFile.
+        (Get-Item -Path $script:SubDir).LastWriteTime = (Get-Date).AddDays(-15)
+    }
+
+    AfterAll {
+        if (Test-Path -Path $script:TempDir) {
+            Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+        }
+    }
+
+    Context -Name 'happy path with recursion (default)' -Fixture {
+        BeforeAll { $script:Result = Get-ItemAge -Path $script:TempDir -AgeInDays 7 }
+
+        It -Name 'reports Deep=$true when -NoRecurse is not specified' -Test {
+            $script:Result.Deep | Should -BeTrue
+        }
+
+        It -Name 'counts files including nested directory contents' -Test {
+            # 2 top-level files + 1 nested + 1 directory entry = 4
+            $script:Result.TotalFiles | Should -Be 4
+        }
+
+        It -Name 'puts files older than AgeInDays into the older bucket' -Test {
+            # old.txt (30d), deep.txt (10d), nested dir (15d) are all older than 7 days
+            $script:Result.'OlderThan7-Days' | Should -Be 3
+        }
+
+        It -Name 'puts files newer than AgeInDays into the newer bucket' -Test {
+            # only new.txt (1d) is newer than 7 days
+            $script:Result.'NewerThan7-Days' | Should -Be 1
+        }
+
+        It -Name 'reports Directory as the absolute path' -Test {
+            $script:Result.Directory | Should -Be (Get-Item -Path $script:TempDir).FullName
+        }
+
+        It -Name 'identifies the oldest file as old.txt' -Test {
+            $script:Result.OldestFile.Name | Should -Be 'old.txt'
+        }
+
+        It -Name 'identifies the newest file as new.txt' -Test {
+            $script:Result.NewestFile.Name | Should -Be 'new.txt'
+        }
+    }
+
+    Context -Name '-NoRecurse behavior' -Fixture {
+        It -Name 'reports Deep=$false and excludes nested files when -NoRecurse is specified' -Test {
+            $result = Get-ItemAge -Path $script:TempDir -AgeInDays 7 -NoRecurse
+            $result.Deep       | Should -BeFalse
+            # 2 top-level files + 1 directory entry (the nested subdir itself) = 3
+            $result.TotalFiles | Should -Be 3
+        }
+    }
+
+    Context -Name 'aliases and parameter validation' -Fixture {
+        It -Name 'exposes the Get-DirItemAges alias' -Test {
+            (Get-Alias -Name 'Get-DirItemAges' -ErrorAction Ignore).ResolvedCommandName | Should -Be 'Get-ItemAge'
+        }
+
+        It -Name 'accepts -Path via the Directory alias' -Test {
+            { Get-ItemAge -Directory $script:TempDir -AgeInDays 7 } | Should -Not -Throw
+        }
+
+        It -Name 'rejects a -Path that does not exist' -Test {
+            { Get-ItemAge -Path (Join-Path -Path $script:TempDir -ChildPath 'missing') } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path that is a file rather than a container' -Test {
+            $file = Join-Path -Path $script:TempDir -ChildPath 'old.txt'
+            { Get-ItemAge -Path $file } | Should -Throw
+        }
+
+        It -Name 'rejects -AgeInDays outside the 1..365 range' -Test {
+            { Get-ItemAge -Path $script:TempDir -AgeInDays 0 }   | Should -Throw
+            { Get-ItemAge -Path $script:TempDir -AgeInDays 366 } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Install-ModuleFromZip.tests.ps1
+++ b/Tests/Unit/Install-ModuleFromZip.tests.ps1
@@ -1,0 +1,75 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Install-ModuleFromZip' -Fixture {
+
+    # The Process block reaches for $env:PSModulePath, runs Expand-Archive against the zip,
+    # walks the expanded directory, and calls Move-Item / Get-Module / Unblock-File. End-to-end
+    # mocking would have to fake an entire filesystem tree under TEMP and a matching .psd1, so
+    # body-level coverage here is intentionally minimal — metadata + parameter validation only.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Install-ModuleFromZip' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -Path as mandatory positional parameter' -Test {
+            $param = $script:Cmd.Parameters['Path']
+            $param.Attributes.Mandatory | Should -Contain $true
+            $param.Attributes.Position  | Should -Contain 0
+        }
+
+        It -Name 'declares -Scope with ValidateSet of CurrentUser / AllUsers (defaults to CurrentUser)' -Test {
+            $param = $script:Cmd.Parameters['Scope']
+            $set = $param.Attributes | Where-Object -FilterScript { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $set.ValidValues | Should -Contain 'CurrentUser'
+            $set.ValidValues | Should -Contain 'AllUsers'
+        }
+
+        It -Name 'declares -Replace as a switch parameter' -Test {
+            $script:Cmd.Parameters['Replace'].ParameterType | Should -Be ([System.Management.Automation.SwitchParameter])
+        }
+
+        It -Name 'supports ShouldProcess with High confirm impact' -Test {
+            $cmdletBinding = $script:Cmd.ScriptBlock.Attributes |
+            Where-Object -FilterScript { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $cmdletBinding.SupportsShouldProcess | Should -BeTrue
+            $cmdletBinding.ConfirmImpact         | Should -Be 'High'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        BeforeAll {
+            $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+        }
+
+        AfterAll {
+            if (Test-Path -Path $script:TempDir) {
+                Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+            }
+        }
+
+        It -Name 'rejects a -Path that does not exist' -Test {
+            { Install-ModuleFromZip -Path (Join-Path -Path $script:TempDir -ChildPath 'missing.zip') } | Should -Throw
+        }
+
+        It -Name 'rejects a -Path whose extension is not .zip' -Test {
+            $bogus = Join-Path -Path $script:TempDir -ChildPath 'fake.txt'
+            Set-Content -Path $bogus -Value 'not a zip'
+            { Install-ModuleFromZip -Path $bogus } | Should -Throw
+        }
+
+        It -Name 'rejects a -Scope value outside the validated set' -Test {
+            # Use a non-existent zip to keep the body from running if validation order ever changes.
+            { Install-ModuleFromZip -Path (Join-Path -Path $script:TempDir -ChildPath 'missing.zip') -Scope 'Everyone' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Save-KBFile.tests.ps1
+++ b/Tests/Unit/Save-KBFile.tests.ps1
@@ -59,10 +59,15 @@ Describe -Name 'Save-KBFile' -Fixture {
             }
         }
 
-        It -Name 'errors when both -FilePath and -Name are supplied (current guard behavior)' -Test {
-            # The Process-block guard fires whenever both are specified, regardless of Name.Count.
-            { Save-KBFile -Name 'KB1' -FilePath 'C:\out.cab' -ErrorAction Stop } |
+        It -Name 'errors when -FilePath is combined with more than one -Name' -Test {
+            { Save-KBFile -Name 'KB1', 'KB2' -FilePath 'C:\out.cab' -ErrorAction Stop } |
                 Should -Throw -ExpectedMessage '*only one KB when using FilePath*'
+        }
+
+        It -Name 'allows -FilePath with exactly one -Name' -Test {
+            # Invoke-WebRequest is mocked to return no matching downloads, so the function warns
+            # and returns without ever touching the downloader.
+            { Save-KBFile -Name 'KB1' -FilePath 'C:\out.cab' -ErrorAction Stop } | Should -Not -Throw
         }
     }
 }

--- a/Tests/Unit/Save-KBFile.tests.ps1
+++ b/Tests/Unit/Save-KBFile.tests.ps1
@@ -1,0 +1,68 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Save-KBFile' -Fixture {
+
+    BeforeAll {
+        # The function does two Invoke-WebRequest hops (catalog Search.aspx, then DownloadDialog.aspx)
+        # and then either Start-BitsTransfer (Windows only) or [Net.WebClient]::DownloadFile to grab
+        # the binary. Mock the IWR calls; the search response yields no InputFields/Links so the
+        # function will warn ("no results found") and return without ever invoking a downloader.
+        Mock -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -MockWith {
+            [PSCustomObject] @{
+                InputFields = @()
+                Links       = @()
+                Content     = ''
+            }
+        }
+        Mock -CommandName Write-Warning -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'URL construction' -Fixture {
+        It -Name 'queries catalog.update.microsoft.com/Search.aspx?q=KB<n> with the numeric KB ID' -Test {
+            Save-KBFile -Name 'KB4057119' | Out-Null
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'http://www.catalog.update.microsoft.com/Search.aspx?q=KB4057119' }
+        }
+
+        It -Name 'strips a leading "KB" from -Name when building the search URL' -Test {
+            Save-KBFile -Name '4057119' | Out-Null
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Uri -eq 'http://www.catalog.update.microsoft.com/Search.aspx?q=KB4057119' }
+        }
+
+        It -Name 'issues one search request per -Name when an array is passed' -Test {
+            Save-KBFile -Name 'KB1', 'KB2', 'KB3' | Out-Null
+            Should -Invoke -CommandName Invoke-WebRequest -ModuleName $env:BHProjectName -Times 3 -Exactly `
+                -ParameterFilter { $Uri -like '*Search.aspx?q=KB*' }
+        }
+    }
+
+    Context -Name 'no-results behavior' -Fixture {
+        It -Name 'warns and skips the downloader when the catalog returns no matching downloads' -Test {
+            Save-KBFile -Name 'KB9999999' | Out-Null
+            Should -Invoke -CommandName Write-Warning -ModuleName $env:BHProjectName
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an -Architecture value outside the validated set' -Test {
+            { Save-KBFile -Name 'KB1' -Architecture 'ia64' } | Should -Throw
+        }
+
+        It -Name 'accepts -Architecture values x64, x86, and All' -Test {
+            foreach ($a in 'x64', 'x86', 'All') {
+                { Save-KBFile -Name 'KB1' -Architecture $a } | Should -Not -Throw
+            }
+        }
+
+        It -Name 'errors when both -FilePath and -Name are supplied (current guard behavior)' -Test {
+            # The Process-block guard fires whenever both are specified, regardless of Name.Count.
+            { Save-KBFile -Name 'KB1' -FilePath 'C:\out.cab' -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*only one KB when using FilePath*'
+        }
+    }
+}

--- a/Tests/Unit/Uninstall-MSI.tests.ps1
+++ b/Tests/Unit/Uninstall-MSI.tests.ps1
@@ -1,0 +1,74 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Uninstall-MSI' -Fixture {
+
+    # Uninstall-MSI calls MsiExec.exe and reads HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall.
+    # The Begin block throws on non-Windows hosts before any of that runs, so happy-path execution
+    # can only be exercised on Windows. CI runs on ubuntu-latest, so we limit body-level invocations
+    # to a skip-guarded block and cover the rest via metadata.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Uninstall-MSI' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -ProductId as mandatory positional' -Test {
+            $param = $script:Cmd.Parameters['ProductId']
+            $param.Attributes.Mandatory | Should -Contain $true
+            $param.Attributes.Position  | Should -Contain 0
+        }
+
+        It -Name 'supports ShouldProcess with High confirm impact' -Test {
+            $cmdletBinding = $script:Cmd.ScriptBlock.Attributes |
+            Where-Object -FilterScript { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $cmdletBinding.SupportsShouldProcess | Should -BeTrue
+            $cmdletBinding.ConfirmImpact         | Should -Be 'High'
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -ProductId that does not match the GUID pattern' -Test {
+            { Uninstall-MSI -ProductId 'not-a-guid' } | Should -Throw
+        }
+
+        It -Name 'rejects an empty -ProductId' -Test {
+            { Uninstall-MSI -ProductId '' } | Should -Throw
+        }
+
+        It -Name 'accepts a well-formed all-caps GUID' -Test {
+            # ValidatePattern does not require braces. We use -WhatIf so the function never actually
+            # touches the registry. On non-Windows it will throw with the OS-required message; on
+            # Windows it will short-circuit on "application not found" since the GUID is bogus.
+            if ($IsWindows) {
+                { Uninstall-MSI -ProductId '109A5A16-E09E-4B82-A784-D1780F1190D6' -WhatIf } | Should -Not -Throw
+            }
+            else {
+                { Uninstall-MSI -ProductId '109A5A16-E09E-4B82-A784-D1780F1190D6' -WhatIf } |
+                Should -Throw -ExpectedMessage '*requires Windows*'
+            }
+        }
+    }
+
+    Context -Name 'platform guard' -Fixture {
+        It -Name 'errors with a Windows-required message on non-Windows hosts' -Skip:($IsWindows) -Test {
+            { Uninstall-MSI -ProductId '109A5A16-E09E-4B82-A784-D1780F1190D6' } |
+            Should -Throw -ExpectedMessage '*requires Windows*'
+        }
+    }
+
+    Context -Name 'happy path (Windows only)' -Fixture {
+        It -Name 'reports "Application... not found" when no registry entry matches the GUID' -Skip:(-not $IsWindows) -Test {
+            # Use a GUID that is overwhelmingly unlikely to be installed
+            $result = Uninstall-MSI -ProductId 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'
+            $result | Should -Match 'not found'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds dedicated Pester tests for all 10 file-system functions in the D3 audit row of #109
- Real temp fixtures for path/byte-size/age tests; mocked external commands (Export-Excel, Invoke-WebRequest, etc.) elsewhere
- Windows-only paths are guarded with `-Skip:(-not $IsWindows)`; non-Windows hosts get a metadata-plus-platform-guard fallback

## Coverage added
| Function | Strategy |
|---|---|
| `Export-WebScan` | Real Acunetix XML fixture, mocked `Export-Excel` (begin/process blocks for param + row-count capture) |
| `Get-AlternateDataStream` | Metadata + Windows-only happy path using a real ADS |
| `Get-DirectoryReport` | Real temp tree, log file output, `Get-DirStats` alias check |
| `Get-FileHeader` | Real fixture with known leading bytes |
| `Get-FileInfo` | Cached vs cache-miss IRM paths around the `$Global:FileSignatures` cache |
| `Get-FolderSize` | Real temp tree with deterministic byte sizes |
| `Get-ItemAge` | Real temp tree with backdated `LastWriteTime` (incl. directories, since `-Recurse` returns them) |
| `Install-ModuleFromZip` | Metadata + parameter validation (full Move-Item/Get-Module mocking would be brittle) |
| `Save-KBFile` | Mocked `Invoke-WebRequest`, no-results warning path |
| `Uninstall-MSI` | Metadata + non-Windows platform-guard path |

Refs #109.

## Test plan
- [x] `./Build/build.ps1 -TaskList Test,Cleanup` locally: 973 passed / 0 failed / 5 skipped (5 Windows-only)