### PR TITLE
fix(Build): run windows-only Pester tests in test discovery and CI (refs #109)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,21 @@
 {
-	"name": "${localWorkspaceFolderBasename}",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		"context": "..",
-		"dockerfile": "Dockerfile"
-	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.defaultProfile.linux": "pwsh",
-				"terminal.integrated.defaultProfile.windows": "pwsh",
-				"terminal.integrated.defaultProfile.osx": "pwsh"
-			},
-			"extensions": [
-				"DavidAnson.vscode-markdownlint",
-				"ms-vscode.powershell"
-			]
-		}
-	}
+    "name": "${localWorkspaceFolderBasename}",
+    "build": {
+        // Sets the run context to one level up instead of the .devcontainer folder.
+        "context": "..",
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "pwsh",
+                "terminal.integrated.defaultProfile.windows": "pwsh",
+                "terminal.integrated.defaultProfile.osx": "pwsh"
+            },
+            "extensions": [
+                "DavidAnson.vscode-markdownlint",
+                "ms-vscode.powershell"
+            ]
+        }
+    }
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,11 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -32,6 +36,6 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: Pester Results
+          name: Pester Results (${{ matrix.os }})
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -10,7 +10,11 @@ Properties {
     $lines = '----------------------------------------------------------------------'
 
     # Pester
-    $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*Tests.ps1"
+    # WINDOWS-ONLY TEST FILES USE THE .tests.windows.ps1 SUFFIX AND ONLY RUN ON WINDOWS
+    $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*.tests.ps1"
+    if ($IsWindows) {
+        $TestScripts += Get-ChildItem "$ProjectRoot/Tests/*/*.tests.windows.ps1"
+    }
     $TestFile = "Test-Unit_$($TimeStamp).xml"
 
     # Script Analyzer

--- a/Tests/Unit/Find-WinEvent.tests.windows.ps1
+++ b/Tests/Unit/Find-WinEvent.tests.windows.ps1
@@ -12,11 +12,12 @@ Describe -Name "Find-WinEvent" -Fixture {
         Find-WinEvent -List | Should -BeOfType PSCustomObject
     }
 
+    # ID 9 IS 'EVENT LOG STARTED' (SYSTEM/6005) WHICH EXISTS ON EVERY BOOTED WINDOWS SYSTEM
     It -Name "should return EventLogRecord" -Test {
-        Find-WinEvent -Id 5 -Results 5 | Should -BeOfType System.Diagnostics.Eventing.Reader.EventLogRecord
+        Find-WinEvent -Id 9 -Results 5 | Should -BeOfType System.Diagnostics.Eventing.Reader.EventLogRecord
     }
 
-    It -Name "should return 5 objects" -Test {
-        Find-WinEvent -Id 3 -Results 5 | Should -HaveCount 5
+    It -Name "should limit results to the requested count" -Test {
+        Find-WinEvent -Id 9 -Results 1 | Should -HaveCount 1
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two stacked problems that kept the `.tests.windows.ps1` files from ever running: the build script's test-discovery glob (`Tests/*/*Tests.ps1`) silently excluded them, and CI had no Windows runner to execute them on. Running the previously-invisible tests for the first time surfaced two latent failures (an environment-dependent `Find-WinEvent` assertion and tab indentation in `devcontainer.json` that the Meta tests only see on Windows), both fixed here.

Refs #109 — unblocks the D4 registry / system info slice. (Intentionally not `closes`; the umbrella issue stays open until all slices land.)

## Changes

- `Build/build.psake.ps1` — test discovery now matches `*.tests.ps1` plus, on Windows only, `*.tests.windows.ps1`. The filename suffix remains the platform contract, enforced in one place.
- `.github/workflows/validate.yml` — `validate` job converted to an OS matrix (`ubuntu-latest`, `windows-latest`) with `fail-fast: false`; Pester artifact name suffixed with the OS to avoid upload collisions.
- `Tests/Unit/Find-WinEvent.tests.windows.ps1` — assertions re-pointed from event table Id 5 / Id 3 (MSI-install events not guaranteed to exist) to Id 9 (Event Log Started, System/6005, present on every booted Windows system); count assertion now requests 1 result instead of assuming 5 matching events exist.
- `.devcontainer/devcontainer.json` — tabs converted to spaces. Latent `Meta.Tests.ps1` failure: dotfolders are hidden on Linux so the tab check never scanned this file on `ubuntu-latest`, but it fails on any Windows run.

## Validation

- [x] `./Build/build.ps1 -TaskList Test, Cleanup` on Windows 11 / PS 7.6.2: 986 discovered (54 files, both windows test files now included), 984 passed / 0 failed / 2 skipped
- [x] `./Build/build.ps1 -TaskList Analyze` on Windows: pass (pre-existing warnings only, below Error threshold)
- [x] CI green on both matrix legs (windows leg runs the windows-only tests for the first time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
