### PR TITLE
test(SecurityTools): add D4 registry/system info test coverage (refs #109)

### DIFF
--- a/Tests/Unit/Find-LANHost.tests.ps1
+++ b/Tests/Unit/Find-LANHost.tests.ps1
@@ -1,0 +1,47 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Find-LANHost' -Fixture {
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Find-LANHost' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -IP as mandatory' -Test {
+            $script:Cmd.Parameters['IP'].Attributes.Mandatory | Should -Contain $true
+        }
+
+        It -Name 'declares -ClearARPCache as a switch' -Test {
+            $script:Cmd.Parameters['ClearARPCache'].ParameterType |
+                Should -Be ([System.Management.Automation.SwitchParameter])
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -DelayMS above 15000' -Test {
+            { Find-LANHost -IP '127.0.0.1' -DelayMS 20000 } | Should -Throw
+        }
+
+        It -Name 'rejects a negative -DelayMS' -Test {
+            { Find-LANHost -IP '127.0.0.1' -DelayMS -1 } | Should -Throw
+        }
+    }
+
+    Context -Name 'scan (Windows only)' -Fixture {
+        # The scan sends UDP datagrams to the supplied addresses and parses arp.exe output;
+        # arp ships with Windows but not with the Linux CI image. Loopback never produces a
+        # dynamic ARP entry, so a successful scan returns nothing.
+        It -Name 'completes a loopback scan without error and returns no dynamic entries' -Skip:(-not $IsWindows) -Test {
+            $result = Find-LANHost -IP '127.0.0.1' -DelayMS 0
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Unit/Get-ADUserStatus.tests.ps1
+++ b/Tests/Unit/Get-ADUserStatus.tests.ps1
@@ -1,0 +1,74 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+
+    # Get-ADUser comes from the ActiveDirectory RSAT module, which is only present on
+    # domain-tooled Windows hosts; tests adapt to whether it is installed
+    $HasActiveDirectory = [bool] (Get-Module -ListAvailable -Name 'ActiveDirectory')
+}
+
+Describe -Name 'Get-ADUserStatus' -Fixture {
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-ADUserStatus' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -Identity as mandatory' -Test {
+            $script:Cmd.Parameters['Identity'].Attributes.Mandatory | Should -Contain $true
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an empty -Identity' -Test {
+            { Get-ADUserStatus -Identity '' } | Should -Throw
+        }
+    }
+
+    Context -Name 'ActiveDirectory module dependency' -Fixture {
+        # The Begin block hard-imports ActiveDirectory with -ErrorAction Stop; on hosts without
+        # RSAT this must surface as a terminating error instead of running with missing commands
+        It -Name 'throws when the ActiveDirectory module is unavailable' -Skip:$HasActiveDirectory -Test {
+            { Get-ADUserStatus -Identity 'jsmith' } | Should -Throw
+        }
+    }
+
+    Context -Name 'user lookup (requires ActiveDirectory module)' -Fixture {
+        # Get-ADUser is mocked so no domain controller is contacted; this only runs on hosts
+        # where RSAT is installed because the mock target must resolve. Import-Module is also
+        # mocked to keep the test hermetic. Note Get-ADUser types -Identity as [ADUser], so the
+        # parameter filter must stringify the bound value before comparing.
+        BeforeAll {
+            if (Get-Module -ListAvailable -Name 'ActiveDirectory') {
+                Mock -CommandName Import-Module -MockWith { } -ModuleName $env:BHProjectName
+                Mock -CommandName Get-ADUser -MockWith {
+                    [PSCustomObject] @{
+                        CN                     = 'jsmith'
+                        EmailAddress           = 'jsmith@example.com'
+                        Created                = Get-Date '2020-01-01'
+                        Enabled                = $true
+                        LastLogonDate          = Get-Date '2026-06-01'
+                        LockedOut              = $false
+                        PasswordExpired        = $false
+                        BadLogonCount          = 0
+                        PasswordLastSet        = Get-Date '2026-05-01'
+                    }
+                } -ModuleName $env:BHProjectName
+            }
+        }
+
+        It -Name 'queries the requested identity and selects the status property set' -Skip:(-not $HasActiveDirectory) -Test {
+            $status = Get-ADUserStatus -Identity 'jsmith'
+            Should -Invoke -CommandName Get-ADUser -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { "$Identity" -eq 'jsmith' }
+            $status.CN        | Should -Be 'jsmith'
+            $status.Enabled   | Should -BeTrue
+            $status.LockedOut | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
+++ b/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
@@ -7,8 +7,9 @@ BeforeDiscovery {
 Describe -Name 'Get-ActiveGatewayUser' -Fixture {
 
     # The function's -ComputerName parameter has a [ValidateScript({ Test-Connection ... })] guard
-    # that fires in caller scope before the function body runs, so we cannot invoke it under a unit
-    # test without a reachable RDG host. We exercise only the command's published metadata here.
+    # that fires before the function body runs, so invoking it requires a reachable target; the
+    # execution tests below use localhost (always answers) with Get-CimInstance mocked so no real
+    # RDG host is needed.
 
     Context -Name 'command metadata' -Fixture {
         BeforeAll {
@@ -32,6 +33,37 @@ Describe -Name 'Get-ActiveGatewayUser' -Fixture {
             $param.Aliases                             | Should -Contain 'Computer'
             $param.Aliases                             | Should -Contain 'System'
             $param.Aliases                             | Should -Contain 'Target'
+        }
+    }
+
+    Context -Name 'connection listing (Windows only)' -Fixture {
+        # The Begin-block platform guard means execution only happens on Windows. Get-CimInstance
+        # is mocked, so neither the TerminalServices WMI namespace nor a real gateway is required.
+        BeforeAll {
+            Mock -CommandName Get-CimInstance -MockWith {
+                [PSCustomObject] @{
+                    UserName           = 'CONTOSO\jdoe'
+                    ClientAddress      = '203.0.113.10'
+                    ConnectedTime      = '20260610080000.000000-300'
+                    ConnectionDuration = '00000000010203.000000:000'
+                    ConnectedResource  = 'rdp-host-01'
+                }
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'queries Win32_TSGatewayConnection in the TerminalServices namespace' -Skip:(-not $IsWindows) -Test {
+            Get-ActiveGatewayUser -ComputerName 'localhost' | Out-Null
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $ClassName -eq 'Win32_TSGatewayConnection' -and $Namespace -eq 'root\cimv2\TerminalServices' }
+        }
+
+        It -Name 'converts ConnectedTime and ConnectionDuration to readable values' -Skip:(-not $IsWindows) -Test {
+            $conn = Get-ActiveGatewayUser -ComputerName 'localhost'
+            $conn.UserName          | Should -Be 'CONTOSO\jdoe'
+            $conn.ClientAddress     | Should -Be '203.0.113.10'
+            $conn.ConnectionTime    | Should -Be (Get-Date -Date '2026-06-10 08:00:00')
+            $conn.ElapsedTime       | Should -Be '01:02:03'
+            $conn.ConnectedResource | Should -Be 'rdp-host-01'
         }
     }
 }

--- a/Tests/Unit/Get-LoggedOnUser.tests.ps1
+++ b/Tests/Unit/Get-LoggedOnUser.tests.ps1
@@ -1,0 +1,50 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-LoggedOnUser' -Fixture {
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-LoggedOnUser' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -ComputerName as optional with the CN alias' -Test {
+            $param = $script:Cmd.Parameters['ComputerName']
+            $param.Attributes.Mandatory | Should -Not -Contain $true
+            $param.Aliases              | Should -Contain 'CN'
+        }
+    }
+
+    Context -Name 'local execution' -Fixture {
+        # query.exe only exists on Windows and the remote branch needs a reachable PSSession,
+        # so both session-listing calls are mocked. Get-Module is mocked to return nothing so
+        # the function takes the plain "query user" branch that does not depend on
+        # Microsoft.PowerShell.TextUtility.
+        BeforeAll {
+            $mockSessions = 'USERNAME  SESSIONNAME  ID  STATE'
+            Mock -CommandName Get-Module -MockWith { $null } -ModuleName $env:BHProjectName
+            Mock -CommandName Invoke-Command -MockWith { $mockSessions } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'runs the query locally when no ComputerName is provided' -Test {
+            Get-LoggedOnUser | Should -Be 'USERNAME  SESSIONNAME  ID  STATE'
+            Should -Invoke -CommandName Invoke-Command -ModuleName $env:BHProjectName -Times 1 -Exactly
+        }
+
+        # The -ComputerName ValidateScript pings the target before the body runs, so this can
+        # only use localhost; localhost is in the function's self-reference list, which must
+        # route to local execution rather than New-PSSession.
+        It -Name 'treats localhost as the local system rather than opening a remote session' -Skip:(-not $IsWindows) -Test {
+            Get-LoggedOnUser -ComputerName 'localhost' | Should -Be 'USERNAME  SESSIONNAME  ID  STATE'
+            Should -Invoke -CommandName Invoke-Command -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $null -eq $Session }
+        }
+    }
+}

--- a/Tests/Unit/Get-MsiInfo.tests.ps1
+++ b/Tests/Unit/Get-MsiInfo.tests.ps1
@@ -1,0 +1,45 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-MsiInfo' -Fixture {
+
+    # Reading the property table of a real MSI requires the WindowsInstaller COM object plus a
+    # binary .msi fixture, neither of which suits a unit test, so the happy path is not
+    # exercised here. The validation and error paths below all run before COM is touched.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-MsiInfo' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -Path as mandatory with pipeline support' -Test {
+            $param = $script:Cmd.Parameters['Path']
+            $param.Attributes.Mandatory                       | Should -Contain $true
+            $param.Attributes.ValueFromPipeline               | Should -Contain $true
+            $param.Attributes.ValueFromPipelineByPropertyName | Should -Contain $true
+        }
+    }
+
+    Context -Name 'error paths' -Fixture {
+        It -Name 'rejects an empty path' -Test {
+            { Get-MsiInfo -Path '' } | Should -Throw
+        }
+
+        It -Name 'throws when the file is not an msi' -Test {
+            $file = Join-Path -Path $TestDrive -ChildPath 'installer.txt'
+            Set-Content -Path $file -Value 'not an msi'
+            { Get-MsiInfo -Path $file } | Should -Throw -ExpectedMessage '*must be an msi*'
+        }
+
+        It -Name 'throws when a relative path cannot be resolved' -Test {
+            { Get-MsiInfo -Path 'no-such-dir/missing.msi' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-RSOP.tests.ps1
+++ b/Tests/Unit/Get-RSOP.tests.ps1
@@ -1,0 +1,53 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+
+    # Get-GPResultantSetOfPolicy comes from the GroupPolicy RSAT module, which is only present
+    # on domain-tooled Windows hosts; tests adapt to whether it is installed
+    $HasGroupPolicy = [bool] (Get-Module -ListAvailable -Name 'GroupPolicy')
+}
+
+Describe -Name 'Get-RSOP' -Fixture {
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Get-RSOP' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -Path as mandatory' -Test {
+            $script:Cmd.Parameters['Path'].Attributes.Mandatory | Should -Contain $true
+        }
+
+        It -Name 'limits -ReportType to HTML and XML' -Test {
+            $validateSet = $script:Cmd.Parameters['ReportType'].Attributes |
+                Where-Object -FilterScript { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $validateSet.ValidValues | Should -Be @('HTML', 'XML')
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a report path in a nonexistent directory' -Test {
+            $badPath = Join-Path -Path $TestDrive -ChildPath 'no-such-dir' -AdditionalChildPath 'rsop.html'
+            { Get-RSOP -Path $badPath } | Should -Throw
+        }
+
+        It -Name 'rejects a -ReportType outside the valid set' -Test {
+            $path = Join-Path -Path $TestDrive -ChildPath 'rsop.pdf'
+            { Get-RSOP -Path $path -ReportType 'PDF' } | Should -Throw
+        }
+    }
+
+    Context -Name 'GroupPolicy module dependency' -Fixture {
+        # The Begin block hard-imports GroupPolicy with -ErrorAction Stop; on hosts without
+        # RSAT this must surface as a terminating error instead of running with missing commands
+        It -Name 'throws when the GroupPolicy module is unavailable' -Skip:$HasGroupPolicy -Test {
+            $path = Join-Path -Path $TestDrive -ChildPath 'rsop.html'
+            { Get-RSOP -Path $path } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Get-SavedHistory.tests.ps1
+++ b/Tests/Unit/Get-SavedHistory.tests.ps1
@@ -25,8 +25,8 @@ Describe -Name 'Get-SavedHistory' -Fixture {
 
     Context -Name 'parameter validation' -Fixture {
         It -Name 'declares -Search as mandatory' -Test {
-            (Get-Command -Name 'Get-SavedHistory').Parameters['Search'].Attributes.Mandatory |
-                Should -Contain $true
+            (Get-Command -Name 'Get-SavedHistory' -Module $env:BHProjectName).Parameters['Search'].Attributes.Mandatory |
+            Should -Contain $true
         }
 
         It -Name 'rejects an empty search phrase' -Test {

--- a/Tests/Unit/Get-SavedHistory.tests.ps1
+++ b/Tests/Unit/Get-SavedHistory.tests.ps1
@@ -1,0 +1,62 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-SavedHistory' -Fixture {
+
+    BeforeAll {
+        # Redirect the PSReadLine history lookup to a fixture file so results are deterministic
+        $historyFile = Join-Path -Path $TestDrive -ChildPath 'history.txt'
+        @(
+            'Get-Process -Name pwsh'
+            'Get-Service -Name BITS'
+            'Get-Process -Name pwsh'
+            'Get-Process -Id 42'
+            '(Get-PSReadLineOption).HistorySavePath'
+            'Get-SavedHistory -Search Get-Service'
+        ) | Set-Content -Path $historyFile
+
+        Mock -CommandName Get-PSReadLineOption -MockWith {
+            [PSCustomObject] @{ HistorySavePath = $historyFile }
+        } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'declares -Search as mandatory' -Test {
+            (Get-Command -Name 'Get-SavedHistory').Parameters['Search'].Attributes.Mandatory |
+                Should -Contain $true
+        }
+
+        It -Name 'rejects an empty search phrase' -Test {
+            { Get-SavedHistory -Search '' } | Should -Throw
+        }
+    }
+
+    Context -Name 'history search' -Fixture {
+        It -Name 'returns commands matching the search phrase with duplicates removed' -Test {
+            $result = Get-SavedHistory -Search 'Get-Process'
+            $result             | Should -HaveCount 2
+            $result.CommandLine | Should -Contain 'Get-Process -Name pwsh'
+            $result.CommandLine | Should -Contain 'Get-Process -Id 42'
+        }
+
+        It -Name 'numbers results sequentially starting at 1' -Test {
+            $result = Get-SavedHistory -Search 'Get-Process'
+            $result.Id | Should -Be @(1, 2)
+        }
+
+        It -Name 'returns nothing when no command matches' -Test {
+            Get-SavedHistory -Search 'Remove-VeryUnlikelyCommandName' | Should -BeNullOrEmpty
+        }
+
+        It -Name 'excludes history entries that reference HistorySavePath' -Test {
+            Get-SavedHistory -Search 'PSReadLineOption' | Should -BeNullOrEmpty
+        }
+
+        It -Name 'excludes prior Get-SavedHistory invocations from results' -Test {
+            Get-SavedHistory -Search 'Get-Service' | Should -HaveCount 1
+        }
+    }
+}

--- a/Tests/Unit/Get-Software.tests.windows.ps1
+++ b/Tests/Unit/Get-Software.tests.windows.ps1
@@ -24,4 +24,14 @@ Describe -Name "Get-Software" -Fixture {
         $Software = Get-Software -Name "PowerShell 7-x64"
         $Software.Name | Should -Be "PowerShell 7-x64"
     }
+
+    It -Name "returns nothing when no installed software matches the name" -Test {
+        Get-Software -Name "No Such Application 1234567890" | Should -BeNullOrEmpty
+    }
+
+    It -Name "still returns machine-hive software with -ExcludeUsers" -Test {
+        $Software = Get-Software -ExcludeUsers 3>$null
+        $Software | Should -Not -BeNullOrEmpty
+        $Software | Should -BeOfType System.Management.Automation.PSObject
+    }
 }

--- a/Tests/Unit/Get-WinInfo.tests.ps1
+++ b/Tests/Unit/Get-WinInfo.tests.ps1
@@ -1,0 +1,54 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-WinInfo' -Fixture {
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an -Id above the information model range' -Test {
+            { Get-WinInfo -Id 99 } | Should -Throw
+        }
+
+        It -Name 'rejects an -Id of zero' -Test {
+            { Get-WinInfo -Id 0 } | Should -Throw
+        }
+    }
+
+    Context -Name 'platform guard' -Fixture {
+        It -Name 'errors when not running on Windows' -Skip:$IsWindows -Test {
+            { Get-WinInfo -List -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*requires Windows*'
+        }
+    }
+
+    Context -Name 'list mode (Windows only)' -Fixture {
+        It -Name 'returns the formatted class list without error' -Skip:(-not $IsWindows) -Test {
+            { Get-WinInfo -List } | Should -Not -Throw
+            Get-WinInfo -List | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'info mode (Windows only)' -Fixture {
+        # Get-CimInstance is mocked so no real WMI/CIM query runs; these tests verify the
+        # information model entry selected by -Id is translated into the right CIM parameters
+        BeforeAll {
+            Mock -CommandName Get-CimInstance -MockWith {
+                [PSCustomObject] @{ Name = 'MockedInstance' }
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'queries the namespace and class selected by -Id' -Skip:(-not $IsWindows) -Test {
+            Get-WinInfo -Id 1 | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $Namespace -eq 'root/CIMV2' -and $ClassName -eq 'cim_process' }
+        }
+
+        It -Name 'applies the class filter when the model defines one' -Skip:(-not $IsWindows) -Test {
+            Get-WinInfo -Id 4 | Out-Null
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $ClassName -eq 'win32_ntlogevent' -and $Filter -like '*logfile*' }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

D4 slice of the test coverage audit (refs #109): dedicated Pester tests for the registry / system-info functions, all previously untested, plus the Group C `Get-Software` deepening that rides with this group.

## Coverage added

| Function | What is covered |
|---|---|
| `Get-LoggedOnUser` | metadata (optional `-ComputerName`, `CN` alias); mocked local execution; localhost self-reference routing (no `New-PSSession`) |
| `Get-SavedHistory` | mocked `Get-PSReadLineOption` pointed at a fixture history file; match filtering, de-duplication, sequential Ids, no-match case, `HistorySavePath`/`Get-SavedHistory` self-reference exclusions |
| `Get-MsiInfo` | metadata (mandatory pipeline-bound `-Path`); empty path, non-msi extension, unresolvable relative path error paths |
| `Get-WinInfo` | `-Id` range validation; non-Windows platform guard; `-List` mode; mocked `Get-CimInstance` verifying namespace/class selection by `-Id` and filter pass-through |
| `Get-RSOP` | metadata (`-ReportType` ValidateSet, mandatory `-Path`); nonexistent-directory and invalid-ReportType validation; GroupPolicy module dependency failure |
| `Get-ADUserStatus` | metadata; empty `-Identity` validation; ActiveDirectory module dependency failure; mocked `Get-ADUser` lookup with property-set selection (runs on RSAT hosts only) |
| `Find-LANHost` | metadata (mandatory `-IP`, switch `-ClearARPCache`); `-DelayMS` range validation; Windows-only loopback scan (no dynamic ARP entries expected) |
| `Get-ActiveGatewayUser` | new: mocked `Win32_TSGatewayConnection` query asserting namespace/class plus `ConnectedTime`/`ConnectionDuration` regex transformations |
| `Get-Software` | new: software-not-found returns nothing; `-ExcludeUsers` still returns machine-hive entries |

## Notes

- All system dependencies (CIM/WMI, AD, PSReadLine, `query`, PSSessions) are mocked — no test touches a real domain controller, gateway, or remote host. The `Find-LANHost` scan only sends a UDP datagram to loopback.
- `Get-MsiInfo`'s happy path is intentionally not exercised: it requires the WindowsInstaller COM object plus a binary `.msi` fixture, which doesn't suit a unit test. Error paths run before COM is touched.
- `Get-Software` "registry permission denied" (from the issue) isn't feasibly simulated in-process without changing ACLs on real hives, so it is not covered.
- The mocked `Get-ADUser` test discovered a subtlety worth noting for future AD tests: `-Identity` binds as `[ADUser]`, so `Should -Invoke` parameter filters must stringify the value before comparing.
- Local suite: 1029 discovered / 1025 passed / 0 failed / 4 skipped (`Build/build.ps1 -TaskList Test, Cleanup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
