### PR TITLE
test(SecurityTools): add D6 report export test coverage (refs #109)

### DIFF
--- a/Tests/Unit/Export-SQLVAReport.tests.ps1
+++ b/Tests/Unit/Export-SQLVAReport.tests.ps1
@@ -1,0 +1,68 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-SQLVAReport' -Fixture {
+
+    # The Begin block hard-imports the SqlServer module and the function body invokes the
+    # SQL Vulnerability Assessment cmdlets, which only exist on hosts where SqlServer is
+    # installed. The -ServerName parameter additionally pings the target via a
+    # Test-Connection ValidateScript in caller scope. Together these prevent a meaningful
+    # happy-path test inside the unit suite, so we cover metadata, parameter validation,
+    # and the SqlServer module dependency failure here.
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Export-SQLVAReport' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -ServerName as mandatory with the SN/Server aliases and pipeline binding' -Test {
+            $param = $script:Cmd.Parameters['ServerName']
+            $param.Attributes.Mandatory         | Should -Contain $true
+            $param.Attributes.ValueFromPipeline | Should -Contain $true
+            $param.Aliases                      | Should -Contain 'SN'
+            $param.Aliases                      | Should -Contain 'Server'
+        }
+
+        It -Name 'declares -PassThru as a switch parameter' -Test {
+            $script:Cmd.Parameters['PassThru'].ParameterType |
+            Should -Be ([System.Management.Automation.SwitchParameter])
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -ServerName that does not respond to a ping' -Test {
+            { Export-SQLVAReport -ServerName 'no-such-host.invalid' } | Should -Throw
+        }
+
+        It -Name 'rejects a -BaselinePath that is not a .json file' -Test {
+            $notJson = Join-Path -Path $TestDrive -ChildPath 'baseline.txt'
+            Set-Content -Path $notJson -Value 'fixture'
+            { Export-SQLVAReport -ServerName 'no-such-host.invalid' -BaselinePath $notJson } | Should -Throw
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            { Export-SQLVAReport -ServerName 'no-such-host.invalid' -OutputDirectory (Join-Path -Path $TestDrive -ChildPath 'nope') } |
+            Should -Throw
+        }
+    }
+
+    Context -Name 'SqlServer module dependency' -Fixture {
+        # The Begin block does Import-Module SqlServer -ErrorAction Stop. On hosts without
+        # the SqlServer RSAT module this must surface as a terminating error before the
+        # function body runs. The test is skipped when the module happens to be installed.
+        $HasSqlServer = [bool] (Get-Module -ListAvailable -Name 'SqlServer')
+
+        It -Name 'throws when the SqlServer module is unavailable' -Skip:$HasSqlServer -Test {
+            # ValidateScript on -ServerName needs a reachable host; use localhost so binding
+            # succeeds and the SqlServer Import-Module failure is what we observe.
+            { Export-SQLVAReport -ServerName 'localhost' -ErrorAction Stop } | Should -Throw
+        }
+    }
+}

--- a/Tests/Unit/Export-SQLVAReportAggregate.tests.ps1
+++ b/Tests/Unit/Export-SQLVAReportAggregate.tests.ps1
@@ -1,0 +1,93 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-SQLVAReportAggregate' -Fixture {
+
+    BeforeAll {
+        # The function discovers reports via Get-ChildItem '<InputPath>\*.xlsx', then pipes each
+        # through Import-Excel. We stage a folder of fixture .xlsx files (just empty marker files
+        # — Import-Excel is mocked) and return synthetic scan rows from the mock.
+        $script:InputDir = Join-Path -Path $TestDrive -ChildPath 'in'
+        New-Item -Path $script:InputDir -ItemType Directory -Force | Out-Null
+        $script:Report1 = Join-Path -Path $script:InputDir -ChildPath 'sql-01.xlsx'
+        $script:Report2 = Join-Path -Path $script:InputDir -ChildPath 'sql-02.xlsx'
+        Set-Content -Path $script:Report1 -Value 'fixture'
+        Set-Content -Path $script:Report2 -Value 'fixture'
+
+        $script:OutFile = Join-Path -Path $TestDrive -ChildPath 'aggregate.xlsx'
+
+        Mock -CommandName Import-Module -MockWith {} -ModuleName $env:BHProjectName `
+            -ParameterFilter { $Name -eq 'ImportExcel' }
+
+        Mock -CommandName Import-Excel -ModuleName $env:BHProjectName -MockWith {
+            @(
+                [PSCustomObject] @{ ID = 'VA1001'; Status = 'Fail';    Risk = 'High' }
+                [PSCustomObject] @{ ID = 'VA1002'; Status = 'Pass';    Risk = 'Low'  }
+                [PSCustomObject] @{ ID = 'VA1003'; Status = 'Warning'; Risk = 'Medium' }
+            )
+        }
+        Mock -CommandName Export-Excel    -MockWith {} -ModuleName $env:BHProjectName
+        Mock -CommandName New-ExcelStyle  -MockWith { @{} } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Export-SQLVAReportAggregate' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'defaults to the folder parameter set' -Test {
+            $script:Cmd.DefaultParameterSet | Should -Be 'folder'
+        }
+
+        It -Name 'declares -InputPath and -ZipPath as mutually exclusive mandatory parameters' -Test {
+            $script:Cmd.Parameters['InputPath'].ParameterSets['folder'].IsMandatory | Should -BeTrue
+            $script:Cmd.Parameters['ZipPath'].ParameterSets['zip'].IsMandatory      | Should -BeTrue
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects an -InputPath folder containing no .xlsx files' -Test {
+            $empty = Join-Path -Path $TestDrive -ChildPath 'empty'
+            New-Item -Path $empty -ItemType Directory -Force | Out-Null
+            { Export-SQLVAReportAggregate -InputPath $empty } | Should -Throw
+        }
+
+        It -Name 'rejects a -ZipPath that is not a .zip file' -Test {
+            $notZip = Join-Path -Path $TestDrive -ChildPath 'sql.xlsx'
+            Set-Content -Path $notZip -Value 'fixture'
+            { Export-SQLVAReportAggregate -ZipPath $notZip } | Should -Throw
+        }
+
+        It -Name 'rejects a -DestinationPath whose extension is not .xlsx' -Test {
+            { Export-SQLVAReportAggregate -InputPath $script:InputDir -DestinationPath (Join-Path -Path $TestDrive -ChildPath 'agg.csv') } | Should -Throw
+        }
+    }
+
+    Context -Name 'aggregation behavior' -Fixture {
+        It -Name 'reads every .xlsx in -InputPath via Import-Excel' -Test {
+            Export-SQLVAReportAggregate -InputPath $script:InputDir -DestinationPath $script:OutFile
+            Should -Invoke -CommandName Import-Excel -ModuleName $env:BHProjectName -Times 2 -Exactly `
+                -ParameterFilter { $WorksheetName -eq 'Results' -and $StartRow -eq 8 }
+        }
+
+        It -Name 'writes the aggregated DBScan worksheet to -DestinationPath' -Test {
+            # Pester counts each pipeline item as a separate Mock invocation, so we assert that
+            # the call happened with the right worksheet and path rather than an exact count.
+            Export-SQLVAReportAggregate -InputPath $script:InputDir -DestinationPath $script:OutFile
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq 'DBScan' -and $Path -eq $script:OutFile }
+        }
+
+        It -Name 'returns the destination path when -PassThru is specified' -Test {
+            $passThru = Export-SQLVAReportAggregate -InputPath $script:InputDir -DestinationPath $script:OutFile -PassThru
+            $passThru | Should -Be $script:OutFile
+        }
+    }
+}

--- a/Tests/Unit/Export-ScanReportAggregate.tests.ps1
+++ b/Tests/Unit/Export-ScanReportAggregate.tests.ps1
@@ -1,0 +1,101 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-ScanReportAggregate' -Fixture {
+
+    BeforeAll {
+        # Each scan branch reads from disk via Import-Csv or Import-Excel and writes one
+        # worksheet via Export-Excel. Tests pre-create empty fixture files for the path
+        # ValidateScripts and mock the import/export cmdlets so no real I/O happens.
+        $script:OutDir = Join-Path -Path $TestDrive -ChildPath 'out'
+        New-Item -Path $script:OutDir -ItemType Directory -Force | Out-Null
+
+        $script:NessusSystemCsv  = Join-Path -Path $TestDrive -ChildPath 'nessus-sys.csv'
+        $script:NessusWebCsv     = Join-Path -Path $TestDrive -ChildPath 'nessus-web.csv'
+        $script:AlertLogicCsv    = Join-Path -Path $TestDrive -ChildPath 'alertlogic.csv'
+        $script:AcunetixCsv      = Join-Path -Path $TestDrive -ChildPath 'acunetix.csv'
+        $script:DatabaseXlsx     = Join-Path -Path $TestDrive -ChildPath 'mssql.xlsx'
+        foreach ($p in $script:NessusSystemCsv, $script:NessusWebCsv, $script:AlertLogicCsv, $script:AcunetixCsv, $script:DatabaseXlsx) {
+            Set-Content -Path $p -Value 'fixture'
+        }
+
+        Mock -CommandName Import-Csv -ModuleName $env:BHProjectName -MockWith {
+            @([PSCustomObject] @{ Name = 'Vuln1'; Severity = 'High'; 'CVSS Score' = '7.5'; 'CVSS3 Score' = '8.1' })
+        }
+        Mock -CommandName Import-Excel -ModuleName $env:BHProjectName -MockWith {
+            @([PSCustomObject] @{ ID = 'DB1'; 'Security Check' = 'Weak password'; Risk = 'High'; Status = 'Fail' })
+        }
+        Mock -CommandName Export-Excel   -MockWith {} -ModuleName $env:BHProjectName
+        Mock -CommandName New-ExcelStyle -MockWith { @{} } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Export-ScanReportAggregate' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares all five scan inputs as optional' -Test {
+            foreach ($name in 'NessusSystemScan', 'NessusWebScan', 'AlertLogicWebScan', 'DatabaseScan', 'AcunetixScan') {
+                $script:Cmd.Parameters[$name].Attributes.Mandatory | Should -Not -Contain $true
+            }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'errors when no scan reports are supplied' -Test {
+            { Export-ScanReportAggregate -OutputDirectory $script:OutDir -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*Missing scan reports*'
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            { Export-ScanReportAggregate -OutputDirectory (Join-Path -Path $TestDrive -ChildPath 'nope') -NessusSystemScan $script:NessusSystemCsv } |
+                Should -Throw
+        }
+
+        It -Name 'rejects a -NessusSystemScan whose extension is not .csv' -Test {
+            { Export-ScanReportAggregate -NessusSystemScan $script:DatabaseXlsx } | Should -Throw
+        }
+    }
+
+    Context -Name 'worksheet routing' -Fixture {
+        It -Name 'writes the AlertLogicWeb worksheet from the AlertLogic scan' -Test {
+            Export-ScanReportAggregate -OutputDirectory $script:OutDir -AlertLogicWebScan $script:AlertLogicCsv
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq 'AlertLogicWeb' }
+        }
+
+        It -Name 'writes the Acunetix worksheet from the Acunetix scan' -Test {
+            Export-ScanReportAggregate -OutputDirectory $script:OutDir -AcunetixScan $script:AcunetixCsv
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq 'Acunetix' }
+        }
+
+        It -Name 'writes the NessusSystem and NessusWeb worksheets from their respective scans' -Test {
+            Export-ScanReportAggregate -OutputDirectory $script:OutDir `
+                -NessusSystemScan $script:NessusSystemCsv -NessusWebScan $script:NessusWebCsv
+            foreach ($sheet in 'NessusSystem', 'NessusWeb') {
+                Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                    -ParameterFilter { $WorksheetName -eq $sheet }
+            }
+        }
+
+        It -Name 'writes the MSSQL worksheet from the database scan' -Test {
+            Export-ScanReportAggregate -OutputDirectory $script:OutDir -DatabaseScan $script:DatabaseXlsx
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq 'MSSQL' }
+        }
+
+        It -Name 'targets a dated Aggregate-Scans workbook in -OutputDirectory' -Test {
+            Export-ScanReportAggregate -OutputDirectory $script:OutDir -NessusSystemScan $script:NessusSystemCsv
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Path -match 'Aggregate-Scans_\d{4}-\d{2}\.xlsx$' -and (Split-Path -Path $Path -Parent) -eq $script:OutDir }
+        }
+    }
+}

--- a/Tests/Unit/Export-ScanReportSummary.tests.ps1
+++ b/Tests/Unit/Export-ScanReportSummary.tests.ps1
@@ -1,0 +1,101 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-ScanReportSummary' -Fixture {
+
+    BeforeAll {
+        # Pre-create empty fixture files so the ValidateScript path checks pass; Import-Csv,
+        # Import-Excel and the Excel writers are mocked, so the on-disk content is irrelevant.
+        $script:NessusSystemCsv = Join-Path -Path $TestDrive -ChildPath 'nessus-sys.csv'
+        $script:NessusWebCsv = Join-Path -Path $TestDrive -ChildPath 'nessus-web.csv'
+        $script:AlertLogicCsv = Join-Path -Path $TestDrive -ChildPath 'alertlogic.csv'
+        $script:AcunetixCsv = Join-Path -Path $TestDrive -ChildPath 'acunetix.csv'
+        $script:DatabaseXlsx = Join-Path -Path $TestDrive -ChildPath 'mssql.xlsx'
+        foreach ($p in $script:NessusSystemCsv, $script:NessusWebCsv, $script:AlertLogicCsv, $script:AcunetixCsv, $script:DatabaseXlsx) {
+            Set-Content -Path $p -Value 'fixture'
+        }
+
+        # Synthetic scan rows. Each branch maps to one fixture row; Sort-Object -Unique on Name
+        # keeps the count predictable at one row per scan source.
+        Mock -CommandName Import-Csv -ModuleName $env:BHProjectName -MockWith {
+            param([System.String] $Path)
+            switch -Wildcard ($Path) {
+                '*nessus-sys.csv' { @([PSCustomObject] @{ Name = 'NesSysFinding'; Risk = 'High'; Status = 'Open'; CVE = 'CVE-2023-1'; CVSS = '7.5'; 'CVSS v3.0 Base Score' = '8.1' }) }
+                '*nessus-web.csv' { @([PSCustomObject] @{ Name = 'NesWebFinding'; Risk = 'Medium'; Status = 'Open'; CVE = 'CVE-2023-2'; CVSS = '5.5'; 'CVSS v3.0 Base Score' = '6.1' }) }
+                '*alertlogic.csv' { @([PSCustomObject] @{ Name = 'CVE-2023-3 vuln'; Severity = 'High'; 'Active or inactive' = 'active'; CVE = 'CVE-2023-3'; CVSS = '7.0' }) }
+                '*acunetix.csv' { @([PSCustomObject] @{ Name = 'AcunetixFinding'; Severity = 'medium'; IsFalsePositive = '0'; CWEList = 'CWE-79'; 'CVSS Score' = '6.4'; 'CVSS3 Score' = '7.1' }) }
+            }
+        }
+        Mock -CommandName Import-Excel -ModuleName $env:BHProjectName -MockWith {
+            @([PSCustomObject] @{ ID = 'DB1'; 'Security Check' = 'Weak password'; Risk = 'High'; Status = 'Fail'; CVSSv3 = '7.5' })
+        }
+        Mock -CommandName Get-CVSSv3BaseScore -ModuleName $env:BHProjectName -MockWith {
+            [PSCustomObject] @{ CVE = 'CVE-2023-3'; Severity = 'High'; Score = 7.8; Vector = 'AV:N' }
+        }
+        Mock -CommandName Export-Excel   -MockWith {} -ModuleName $env:BHProjectName
+        Mock -CommandName New-ExcelStyle -MockWith { @{} } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Export-ScanReportSummary' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares all five scan inputs as optional' -Test {
+            foreach ($name in 'NessusSystemScan', 'NessusWebScan', 'AlertLogicWebScan', 'DatabaseScan', 'AcunetixScan') {
+                $script:Cmd.Parameters[$name].Attributes.Mandatory | Should -Not -Contain $true
+            }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'errors when no scan reports are supplied' -Test {
+            { Export-ScanReportSummary -ErrorAction Stop } |
+            Should -Throw -ExpectedMessage '*Missing scan reports*'
+        }
+
+        It -Name 'rejects a -DestinationPath whose extension is not .xlsx' -Test {
+            { Export-ScanReportSummary -DestinationPath (Join-Path -Path $TestDrive -ChildPath 'summary.csv') -NessusSystemScan $script:NessusSystemCsv } |
+            Should -Throw
+        }
+    }
+
+    Context -Name 'scan routing' -Fixture {
+        It -Name 'writes the summary worksheet named after the current month (uppercase abbrev)' -Test {
+            $monthSheet = (Get-Date -UFormat %b).ToUpper()
+            Export-ScanReportSummary -NessusSystemScan $script:NessusSystemCsv
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq $monthSheet }
+        }
+
+        It -Name 'looks up CVSSv3 for AlertLogic findings that contain a CVE id' -Test {
+            Export-ScanReportSummary -AlertLogicWebScan $script:AlertLogicCsv
+            Should -Invoke -CommandName Get-CVSSv3BaseScore -ModuleName $env:BHProjectName `
+                -ParameterFilter { $CVE -eq 'CVE-2023-3' }
+        }
+
+        It -Name 'reads the database scan workbook from the DBScan worksheet' -Test {
+            Export-ScanReportSummary -DatabaseScan $script:DatabaseXlsx
+            Should -Invoke -CommandName Import-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $WorksheetName -eq 'DBScan' }
+        }
+
+        It -Name 'reads each provided CSV via Import-Csv exactly once' -Test {
+            Export-ScanReportSummary `
+                -NessusSystemScan $script:NessusSystemCsv `
+                -NessusWebScan    $script:NessusWebCsv `
+                -AcunetixScan     $script:AcunetixCsv
+            foreach ($csv in $script:NessusSystemCsv, $script:NessusWebCsv, $script:AcunetixCsv) {
+                Should -Invoke -CommandName Import-Csv -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                    -ParameterFilter { $Path -eq $csv }
+            }
+        }
+    }
+}

--- a/Tests/Unit/Export-ScanReportSummary.tests.ps1
+++ b/Tests/Unit/Export-ScanReportSummary.tests.ps1
@@ -18,6 +18,13 @@ Describe -Name 'Export-ScanReportSummary' -Fixture {
             Set-Content -Path $p -Value 'fixture'
         }
 
+        # When -DestinationPath is not supplied the function assigns the default
+        # ~/Desktop/Summary-Scans_<yyyy-MM>.xlsx, which re-fires the parameter's
+        # ValidateScript on the new value. On runners without a Desktop folder
+        # (e.g. ubuntu-latest) that re-validation fails, so every test supplies an
+        # explicit -DestinationPath under $TestDrive.
+        $script:OutFile = Join-Path -Path $TestDrive -ChildPath 'summary.xlsx'
+
         # Synthetic scan rows. Each branch maps to one fixture row; Sort-Object -Unique on Name
         # keeps the count predictable at one row per scan source.
         Mock -CommandName Import-Csv -ModuleName $env:BHProjectName -MockWith {
@@ -70,19 +77,19 @@ Describe -Name 'Export-ScanReportSummary' -Fixture {
     Context -Name 'scan routing' -Fixture {
         It -Name 'writes the summary worksheet named after the current month (uppercase abbrev)' -Test {
             $monthSheet = (Get-Date -UFormat %b).ToUpper()
-            Export-ScanReportSummary -NessusSystemScan $script:NessusSystemCsv
+            Export-ScanReportSummary -NessusSystemScan $script:NessusSystemCsv -DestinationPath $script:OutFile
             Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
                 -ParameterFilter { $WorksheetName -eq $monthSheet }
         }
 
         It -Name 'looks up CVSSv3 for AlertLogic findings that contain a CVE id' -Test {
-            Export-ScanReportSummary -AlertLogicWebScan $script:AlertLogicCsv
+            Export-ScanReportSummary -AlertLogicWebScan $script:AlertLogicCsv -DestinationPath $script:OutFile
             Should -Invoke -CommandName Get-CVSSv3BaseScore -ModuleName $env:BHProjectName `
                 -ParameterFilter { $CVE -eq 'CVE-2023-3' }
         }
 
         It -Name 'reads the database scan workbook from the DBScan worksheet' -Test {
-            Export-ScanReportSummary -DatabaseScan $script:DatabaseXlsx
+            Export-ScanReportSummary -DatabaseScan $script:DatabaseXlsx -DestinationPath $script:OutFile
             Should -Invoke -CommandName Import-Excel -ModuleName $env:BHProjectName `
                 -ParameterFilter { $WorksheetName -eq 'DBScan' }
         }
@@ -91,7 +98,8 @@ Describe -Name 'Export-ScanReportSummary' -Fixture {
             Export-ScanReportSummary `
                 -NessusSystemScan $script:NessusSystemCsv `
                 -NessusWebScan    $script:NessusWebCsv `
-                -AcunetixScan     $script:AcunetixCsv
+                -AcunetixScan     $script:AcunetixCsv `
+                -DestinationPath  $script:OutFile
             foreach ($csv in $script:NessusSystemCsv, $script:NessusWebCsv, $script:AcunetixCsv) {
                 Should -Invoke -CommandName Import-Csv -ModuleName $env:BHProjectName -Times 1 -Exactly `
                     -ParameterFilter { $Path -eq $csv }

--- a/Tests/Unit/Export-VeracodeReport.tests.ps1
+++ b/Tests/Unit/Export-VeracodeReport.tests.ps1
@@ -1,0 +1,101 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Export-VeracodeReport' -Fixture {
+
+    BeforeAll {
+        # Minimal Veracode detailedreport XML covering the two shapes the function reaches into:
+        # detailedreport.severity[].category.cwe.staticflaws.flaw (vulnerabilities) and
+        # detailedreport.'static-analysis'.modules.module (modules)
+        $script:ReportPath = Join-Path -Path $TestDrive -ChildPath 'veracode.xml'
+        $reportXml = @'
+<?xml version="1.0" encoding="UTF-8"?>
+<detailedreport>
+  <severity level="5">
+    <category categoryname="SQL Injection">
+      <cwe cweid="89">
+        <staticflaws>
+          <flaw severity="5" module="api.dll" type="SQLi" sourcefile="db.cs" line="42" scope="Db.Run" categoryname="SQL Injection" issueid="1001" />
+          <flaw severity="5" module="api.dll" type="SQLi" sourcefile="db.cs" line="77" scope="Db.Run" categoryname="SQL Injection" issueid="1002" />
+        </staticflaws>
+      </cwe>
+    </category>
+  </severity>
+  <severity level="3">
+    <category categoryname="XSS">
+      <cwe cweid="79">
+        <staticflaws>
+          <flaw severity="3" module="web.dll" type="XSS" sourcefile="view.cs" line="10" scope="View.Render" categoryname="XSS" issueid="2001" />
+        </staticflaws>
+      </cwe>
+    </category>
+  </severity>
+  <static-analysis>
+    <modules>
+      <module name="api.dll" compiler="csc" os="Windows" architecture="x64"
+              numflawssev0="0" numflawssev1="0" numflawssev2="0" numflawssev3="0" numflawssev4="0" numflawssev5="2" />
+      <module name="web.dll" compiler="csc" os="Windows" architecture="x64"
+              numflawssev0="0" numflawssev1="0" numflawssev2="0" numflawssev3="1" numflawssev4="0" numflawssev5="0" />
+    </modules>
+  </static-analysis>
+</detailedreport>
+'@
+        Set-Content -Path $script:ReportPath -Value $reportXml -Encoding utf8
+
+        $script:OutDir = Join-Path -Path $TestDrive -ChildPath 'out'
+        New-Item -Path $script:OutDir -ItemType Directory -Force | Out-Null
+
+        # Replace Excel I/O so the test stays hermetic
+        Mock -CommandName Export-Excel    -MockWith {} -ModuleName $env:BHProjectName
+        Mock -CommandName New-ExcelStyle  -MockWith { @{} } -ModuleName $env:BHProjectName
+    }
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Export-VeracodeReport' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -VeracodeXML as mandatory' -Test {
+            $script:Cmd.Parameters['VeracodeXML'].Attributes.Mandatory | Should -Contain $true
+        }
+    }
+
+    Context -Name 'workbook export' -Fixture {
+        It -Name 'writes the Modules and Vulnerabilities worksheets' -Test {
+            Export-VeracodeReport -VeracodeXML $script:ReportPath -OutputDirectory $script:OutDir
+            foreach ($sheet in 'Modules', 'Vulnerabilities') {
+                Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                    -ParameterFilter { $WorksheetName -eq $sheet }
+            }
+        }
+
+        It -Name 'writes a dated VeracodeScan workbook under -OutputDirectory' -Test {
+            Export-VeracodeReport -VeracodeXML $script:ReportPath -OutputDirectory $script:OutDir
+            Should -Invoke -CommandName Export-Excel -ModuleName $env:BHProjectName `
+                -ParameterFilter { $Path -match '\d{4}-\d{2}-\d{2}_VeracodeScan\.xlsx$' -and (Split-Path -Path $Path -Parent) -eq $script:OutDir }
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects a -VeracodeXML path that does not exist' -Test {
+            { Export-VeracodeReport -VeracodeXML (Join-Path -Path $TestDrive -ChildPath 'missing.xml') } | Should -Throw
+        }
+
+        It -Name 'rejects a -VeracodeXML file whose extension is not .xml' -Test {
+            $bogus = Join-Path -Path $TestDrive -ChildPath 'report.txt'
+            Set-Content -Path $bogus -Value '<not xml/>'
+            { Export-VeracodeReport -VeracodeXML $bogus } | Should -Throw
+        }
+
+        It -Name 'rejects an -OutputDirectory that does not exist' -Test {
+            { Export-VeracodeReport -VeracodeXML $script:ReportPath -OutputDirectory (Join-Path -Path $TestDrive -ChildPath 'nope') } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary

D6 slice of the test coverage audit (refs #109): Pester coverage for the five `Export-*` report functions previously without dedicated tests.

## Coverage added

| Function | What is covered |
|---|---|
| `Export-SQLVAReport` | metadata (`-ServerName` mandatory + `SN`/`Server` aliases + pipeline binding, `-PassThru` switch); `-ServerName` `Test-Connection` ValidateScript failure; `-BaselinePath` non-`.json` rejection; `-OutputDirectory` nonexistent rejection; SqlServer module dependency failure (skipped on hosts that have the module) |
| `Export-SQLVAReportAggregate` | metadata (default `folder` parameter set; `-InputPath` / `-ZipPath` mandatory in their sets); validation for an empty `-InputPath` folder, non-`.zip` `-ZipPath`, non-`.xlsx` `-DestinationPath`; mocked `Import-Excel` reads `Results` worksheet at start row 8 for every `.xlsx`; writes `DBScan` worksheet to `-DestinationPath`; `-PassThru` returns the destination |
| `Export-ScanReportAggregate` | metadata (all five scan inputs optional); missing-scan error; `-OutputDirectory` nonexistent rejection; non-CSV `-NessusSystemScan` rejection; per-source worksheet routing (`AlertLogicWeb`, `Acunetix`, `NessusSystem`, `NessusWeb`, `MSSQL`); dated `Aggregate-Scans_YYYY-MM.xlsx` output path |
| `Export-ScanReportSummary` | metadata (all five scan inputs optional); missing-scan error; non-`.xlsx` `-DestinationPath` rejection; current-month uppercase worksheet name; `Get-CVSSv3BaseScore` lookup for AlertLogic findings whose `Name` contains a CVE id; `DBScan` worksheet read; per-CSV `Import-Csv` routing |
| `Export-VeracodeReport` | metadata (`-VeracodeXML` mandatory); `Modules` and `Vulnerabilities` worksheet writes from a Veracode `<detailedreport>` fixture; dated `VeracodeScan` output path; nonexistent / non-`.xml` `-VeracodeXML` and nonexistent `-OutputDirectory` rejection |

## Notes

- All Excel I/O (`Import-Excel`, `Export-Excel`, `New-ExcelStyle`) and `Get-CVSSv3BaseScore` are mocked, so no real workbook is read or written.
- `Export-SQLVAReport`'s happy path is intentionally not covered: the `SqlServer` module and the `Test-Connection` ValidateScript on `-ServerName` cannot both be satisfied in a unit-test environment. The metadata, ValidateScript, and SqlServer module-dependency paths all run before those preconditions matter.
- Pester counts each pipeline item as a separate `Mock` invocation, so worksheet-write assertions use a `-ParameterFilter` without `-Times -Exactly` (same approach as `Export-NPMAudit.tests.ps1`).
- Local suite: 1048 passed / 13 skipped / 0 failed (`./Build/build.ps1 -TaskList Test, Cleanup`).
