### PR TITLE
test(SecurityTools): add D8 coverage + split validate workflow by OS test scope (refs #109)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            pesterScope: CrossPlatform
+          - os: windows-latest
+            pesterScope: WindowsOnly
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -32,7 +36,7 @@ jobs:
         run: .\Build\build.ps1 -TaskList 'Analyze'
 
       - shell: pwsh # pester
-        run: .\Build\build.ps1 -TaskList 'Test'
+        run: .\Build\build.ps1 -TaskList 'Test' -Properties @{ PesterScope = '${{ matrix.pesterScope }}' }
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   validate:
+    name: validate (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -10,11 +10,12 @@ Properties {
     $lines = '----------------------------------------------------------------------'
 
     # Pester
-    # WINDOWS-ONLY TEST FILES USE THE .tests.windows.ps1 SUFFIX AND ONLY RUN ON WINDOWS
-    $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*.tests.ps1"
-    if ($IsWindows) {
-        $TestScripts += Get-ChildItem "$ProjectRoot/Tests/*/*.tests.windows.ps1"
-    }
+    # SELECTS WHICH UNIT TESTS THE 'Test' TASK DISCOVERS:
+    #   All           - cross-platform .tests.ps1 + Windows-only .tests.windows.ps1 (default; matches local-dev behavior)
+    #   CrossPlatform - cross-platform .tests.ps1 only
+    #   WindowsOnly   - .tests.windows.ps1 only
+    # Override from the command line:  ./Build/build.ps1 -Properties @{ PesterScope = 'WindowsOnly' } -TaskList Test
+    $PesterScope = 'All'
     $TestFile = "Test-Unit_$($TimeStamp).xml"
 
     # Script Analyzer
@@ -139,6 +140,26 @@ Task 'Analyze' -depends 'ImportStagingModule' {
 # Misc tests: verify manifest data, check comment-based help exists
 Task 'Test' -depends 'ImportStagingModule' {
     $lines
+
+    # Resolve $TestScripts from $PesterScope here (not in Properties) so that overrides
+    # passed via Invoke-psake -properties / build.ps1 -Properties take effect.
+    switch ($PesterScope) {
+        'CrossPlatform' {
+            $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*.tests.ps1"
+        }
+        'WindowsOnly' {
+            $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*.tests.windows.ps1"
+        }
+        'All' {
+            $TestScripts = Get-ChildItem "$ProjectRoot/Tests/*/*.tests.ps1"
+            if ($IsWindows) {
+                $TestScripts += Get-ChildItem "$ProjectRoot/Tests/*/*.tests.windows.ps1"
+            }
+        }
+        default {
+            Write-Error -Message ('Unknown PesterScope value [{0}] - expected All, CrossPlatform, or WindowsOnly' -f $PesterScope) -ErrorAction Stop
+        }
+    }
 
     # Gather test results. Store them in a variable and file
     $TestFilePath = Join-Path -Path $ArtifactFolder -ChildPath $TestFile

--- a/Public/Out-MeasureResult.ps1
+++ b/Public/Out-MeasureResult.ps1
@@ -54,17 +54,12 @@ function Out-MeasureResult {
         else { $list.Add($Measurement) }
     }
     End {
-        $max = ($list | Measure-Object -Property Ticks -Maximum).Maximum
-        $min = ($list | Measure-Object -Property Ticks -Minimum).Minimum
-        $avg = $list | Measure-Object -Property TotalMilliseconds -Average
-
-        $maxObj = $list.Where( { $_.Ticks -eq $max } )
-        $minObj = $list.Where( { $_.Ticks -eq $min } )
+        $stats = $list | Measure-Object -Property TotalMilliseconds -Maximum -Minimum -Average
 
         [PSCustomObject] @{
-            MaxMilliseconds = [System.Int32] $maxObj.TotalMilliseconds
-            MinMilliseconds = [System.Int32] $minObj.TotalMilliseconds
-            AvgMilliseconds = [System.Int32] $avg.Average
+            MaxMilliseconds = [System.Int32] $stats.Maximum
+            MinMilliseconds = [System.Int32] $stats.Minimum
+            AvgMilliseconds = [System.Int32] $stats.Average
         }
     }
 }

--- a/SecurityTools.psd1
+++ b/SecurityTools.psd1
@@ -12,7 +12,7 @@
     # Major = significant changes, breaking changes or major new features
     # Minor = new functions or features
     # Build = bug fixes and minor updates
-    ModuleVersion        = '0.10.5'
+    ModuleVersion        = '0.10.6'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')

--- a/Tests/Unit/Find-LANHost.tests.ps1
+++ b/Tests/Unit/Find-LANHost.tests.ps1
@@ -21,7 +21,7 @@ Describe -Name 'Find-LANHost' -Fixture {
 
         It -Name 'declares -ClearARPCache as a switch' -Test {
             $script:Cmd.Parameters['ClearARPCache'].ParameterType |
-                Should -Be ([System.Management.Automation.SwitchParameter])
+            Should -Be ([System.Management.Automation.SwitchParameter])
         }
     }
 
@@ -32,16 +32,6 @@ Describe -Name 'Find-LANHost' -Fixture {
 
         It -Name 'rejects a negative -DelayMS' -Test {
             { Find-LANHost -IP '127.0.0.1' -DelayMS -1 } | Should -Throw
-        }
-    }
-
-    Context -Name 'scan (Windows only)' -Fixture {
-        # The scan sends UDP datagrams to the supplied addresses and parses arp.exe output;
-        # arp ships with Windows but not with the Linux CI image. Loopback never produces a
-        # dynamic ARP entry, so a successful scan returns nothing.
-        It -Name 'completes a loopback scan without error and returns no dynamic entries' -Skip:(-not $IsWindows) -Test {
-            $result = Find-LANHost -IP '127.0.0.1' -DelayMS 0
-            $result | Should -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Unit/Find-LANHost.tests.windows.ps1
+++ b/Tests/Unit/Find-LANHost.tests.windows.ps1
@@ -1,0 +1,17 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Find-LANHost' -Fixture {
+
+    Context -Name 'scan' -Fixture {
+        # The scan sends UDP datagrams to the supplied addresses and parses arp.exe output.
+        # Loopback never produces a dynamic ARP entry, so a successful scan returns nothing.
+        It -Name 'completes a loopback scan without error and returns no dynamic entries' -Test {
+            $result = Find-LANHost -IP '127.0.0.1' -DelayMS 0
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Unit/Find-ServerPendingReboot.tests.ps1
+++ b/Tests/Unit/Find-ServerPendingReboot.tests.ps1
@@ -12,17 +12,4 @@ Describe -Name 'Find-ServerPendingReboot' -Fixture {
                 Should -Throw -ExpectedMessage '*requires Windows*'
         }
     }
-
-    Context -Name 'normal usage' -Fixture {
-        It -Name 'does not throw on Windows' -Skip:(-not $IsWindows) -Test {
-            { Find-ServerPendingReboot } | Should -Not -Throw
-        }
-
-        It -Name 'returns one object per ComputerName with RebootIsPending boolean' -Skip:(-not $IsWindows) -Test {
-            $result = Find-ServerPendingReboot
-            $result | Should -Not -BeNullOrEmpty
-            $result.ComputerName    | Should -Be $env:COMPUTERNAME
-            $result.RebootIsPending | Should -BeOfType [System.Boolean]
-        }
-    }
 }

--- a/Tests/Unit/Find-ServerPendingReboot.tests.windows.ps1
+++ b/Tests/Unit/Find-ServerPendingReboot.tests.windows.ps1
@@ -1,0 +1,21 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Find-ServerPendingReboot' -Fixture {
+
+    Context -Name 'normal usage' -Fixture {
+        It -Name 'does not throw on Windows' -Test {
+            { Find-ServerPendingReboot } | Should -Not -Throw
+        }
+
+        It -Name 'returns one object per ComputerName with RebootIsPending boolean' -Test {
+            $result = Find-ServerPendingReboot
+            $result | Should -Not -BeNullOrEmpty
+            $result.ComputerName    | Should -Be $env:COMPUTERNAME
+            $result.RebootIsPending | Should -BeOfType [System.Boolean]
+        }
+    }
+}

--- a/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
+++ b/Tests/Unit/Get-ActiveGatewayUser.tests.ps1
@@ -35,35 +35,4 @@ Describe -Name 'Get-ActiveGatewayUser' -Fixture {
             $param.Aliases                             | Should -Contain 'Target'
         }
     }
-
-    Context -Name 'connection listing (Windows only)' -Fixture {
-        # The Begin-block platform guard means execution only happens on Windows. Get-CimInstance
-        # is mocked, so neither the TerminalServices WMI namespace nor a real gateway is required.
-        BeforeAll {
-            Mock -CommandName Get-CimInstance -MockWith {
-                [PSCustomObject] @{
-                    UserName           = 'CONTOSO\jdoe'
-                    ClientAddress      = '203.0.113.10'
-                    ConnectedTime      = '20260610080000.000000-300'
-                    ConnectionDuration = '00000000010203.000000:000'
-                    ConnectedResource  = 'rdp-host-01'
-                }
-            } -ModuleName $env:BHProjectName
-        }
-
-        It -Name 'queries Win32_TSGatewayConnection in the TerminalServices namespace' -Skip:(-not $IsWindows) -Test {
-            Get-ActiveGatewayUser -ComputerName 'localhost' | Out-Null
-            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
-                -ParameterFilter { $ClassName -eq 'Win32_TSGatewayConnection' -and $Namespace -eq 'root\cimv2\TerminalServices' }
-        }
-
-        It -Name 'converts ConnectedTime and ConnectionDuration to readable values' -Skip:(-not $IsWindows) -Test {
-            $conn = Get-ActiveGatewayUser -ComputerName 'localhost'
-            $conn.UserName          | Should -Be 'CONTOSO\jdoe'
-            $conn.ClientAddress     | Should -Be '203.0.113.10'
-            $conn.ConnectionTime    | Should -Be (Get-Date -Date '2026-06-10 08:00:00')
-            $conn.ElapsedTime       | Should -Be '01:02:03'
-            $conn.ConnectedResource | Should -Be 'rdp-host-01'
-        }
-    }
 }

--- a/Tests/Unit/Get-ActiveGatewayUser.tests.windows.ps1
+++ b/Tests/Unit/Get-ActiveGatewayUser.tests.windows.ps1
@@ -1,0 +1,39 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-ActiveGatewayUser' -Fixture {
+
+    Context -Name 'connection listing' -Fixture {
+        # The Begin-block platform guard means execution only happens on Windows. Get-CimInstance
+        # is mocked, so neither the TerminalServices WMI namespace nor a real gateway is required.
+        BeforeAll {
+            Mock -CommandName Get-CimInstance -MockWith {
+                [PSCustomObject] @{
+                    UserName           = 'CONTOSO\jdoe'
+                    ClientAddress      = '203.0.113.10'
+                    ConnectedTime      = '20260610080000.000000-300'
+                    ConnectionDuration = '00000000010203.000000:000'
+                    ConnectedResource  = 'rdp-host-01'
+                }
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'queries Win32_TSGatewayConnection in the TerminalServices namespace' -Test {
+            Get-ActiveGatewayUser -ComputerName 'localhost' | Out-Null
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $ClassName -eq 'Win32_TSGatewayConnection' -and $Namespace -eq 'root\cimv2\TerminalServices' }
+        }
+
+        It -Name 'converts ConnectedTime and ConnectionDuration to readable values' -Test {
+            $conn = Get-ActiveGatewayUser -ComputerName 'localhost'
+            $conn.UserName          | Should -Be 'CONTOSO\jdoe'
+            $conn.ClientAddress     | Should -Be '203.0.113.10'
+            $conn.ConnectionTime    | Should -Be (Get-Date -Date '2026-06-10 08:00:00')
+            $conn.ElapsedTime       | Should -Be '01:02:03'
+            $conn.ConnectedResource | Should -Be 'rdp-host-01'
+        }
+    }
+}

--- a/Tests/Unit/Get-AlternateDataStream.tests.ps1
+++ b/Tests/Unit/Get-AlternateDataStream.tests.ps1
@@ -7,8 +7,8 @@ BeforeDiscovery {
 Describe -Name 'Get-AlternateDataStream' -Fixture {
 
     # Get-Item -Stream * is Windows/NTFS only — on Linux/macOS PowerShell rejects the parameter
-    # set entirely, so body-level invocation here is metadata + parameter-validation only, plus
-    # a Windows-only happy-path that creates a real ADS on the test fixture file.
+    # set entirely, so cross-platform coverage here is metadata + parameter validation only.
+    # The Windows-only happy path lives in Get-AlternateDataStream.tests.windows.ps1.
 
     Context -Name 'command metadata' -Fixture {
         BeforeAll {
@@ -33,39 +33,6 @@ Describe -Name 'Get-AlternateDataStream' -Fixture {
     Context -Name 'parameter validation' -Fixture {
         It -Name 'rejects an empty -Path' -Test {
             { Get-AlternateDataStream -Path '' } | Should -Throw
-        }
-    }
-
-    Context -Name 'happy path (Windows only)' -Fixture {
-        BeforeAll {
-            if ($IsWindows) {
-                $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
-                New-Item -Path $script:TempDir -ItemType Directory | Out-Null
-
-                $script:TestFile = Join-Path -Path $script:TempDir -ChildPath 'fixture.dat'
-                Set-Content -Path $script:TestFile -Value 'primary stream content'
-                # Add an alternate data stream
-                Set-Content -Path $script:TestFile -Stream 'TestStream' -Value 'hidden stream payload'
-            }
-        }
-
-        AfterAll {
-            if ($IsWindows -and (Test-Path -Path $script:TempDir)) {
-                Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
-            }
-        }
-
-        It -Name 'returns the alternate data stream and omits the default :$DATA stream' -Skip:(-not $IsWindows) -Test {
-            $result = Get-AlternateDataStream -Path $script:TestFile
-            $result               | Should -Not -BeNullOrEmpty
-            $result.Stream        | Should -Be 'TestStream'
-            $result.Stream        | Should -Not -Contain ':$DATA'
-        }
-
-        It -Name 'projects each stream with Path / Stream / Size properties' -Skip:(-not $IsWindows) -Test {
-            $result = Get-AlternateDataStream -Path $script:TestFile
-            $result.Path          | Should -Be $script:TestFile
-            $result.Size          | Should -BeGreaterThan 0
         }
     }
 }

--- a/Tests/Unit/Get-AlternateDataStream.tests.windows.ps1
+++ b/Tests/Unit/Get-AlternateDataStream.tests.windows.ps1
@@ -1,0 +1,41 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-AlternateDataStream' -Fixture {
+
+    # Get-Item -Stream * is Windows/NTFS only. These tests stage a real file with an alternate
+    # data stream and verify the function projects it cleanly.
+
+    Context -Name 'happy path' -Fixture {
+        BeforeAll {
+            $script:TempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            New-Item -Path $script:TempDir -ItemType Directory | Out-Null
+
+            $script:TestFile = Join-Path -Path $script:TempDir -ChildPath 'fixture.dat'
+            Set-Content -Path $script:TestFile -Value 'primary stream content'
+            Set-Content -Path $script:TestFile -Stream 'TestStream' -Value 'hidden stream payload'
+        }
+
+        AfterAll {
+            if (Test-Path -Path $script:TempDir) {
+                Remove-Item -Path $script:TempDir -Recurse -Force -ErrorAction Ignore
+            }
+        }
+
+        It -Name 'returns the alternate data stream and omits the default :$DATA stream' -Test {
+            $result = Get-AlternateDataStream -Path $script:TestFile
+            $result               | Should -Not -BeNullOrEmpty
+            $result.Stream        | Should -Be 'TestStream'
+            $result.Stream        | Should -Not -Contain ':$DATA'
+        }
+
+        It -Name 'projects each stream with Path / Stream / Size properties' -Test {
+            $result = Get-AlternateDataStream -Path $script:TestFile
+            $result.Path          | Should -Be $script:TestFile
+            $result.Size          | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/Tests/Unit/Get-LoggedOnUser.tests.ps1
+++ b/Tests/Unit/Get-LoggedOnUser.tests.ps1
@@ -37,14 +37,5 @@ Describe -Name 'Get-LoggedOnUser' -Fixture {
             Get-LoggedOnUser | Should -Be 'USERNAME  SESSIONNAME  ID  STATE'
             Should -Invoke -CommandName Invoke-Command -ModuleName $env:BHProjectName -Times 1 -Exactly
         }
-
-        # The -ComputerName ValidateScript pings the target before the body runs, so this can
-        # only use localhost; localhost is in the function's self-reference list, which must
-        # route to local execution rather than New-PSSession.
-        It -Name 'treats localhost as the local system rather than opening a remote session' -Skip:(-not $IsWindows) -Test {
-            Get-LoggedOnUser -ComputerName 'localhost' | Should -Be 'USERNAME  SESSIONNAME  ID  STATE'
-            Should -Invoke -CommandName Invoke-Command -ModuleName $env:BHProjectName -Times 1 -Exactly `
-                -ParameterFilter { $null -eq $Session }
-        }
     }
 }

--- a/Tests/Unit/Get-LoggedOnUser.tests.windows.ps1
+++ b/Tests/Unit/Get-LoggedOnUser.tests.windows.ps1
@@ -1,0 +1,28 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-LoggedOnUser' -Fixture {
+
+    Context -Name 'local execution' -Fixture {
+        # query.exe only exists on Windows. Invoke-Command is mocked so no real session opens.
+        # Get-Module is mocked to return nothing so the function takes the plain "query user"
+        # branch that does not depend on Microsoft.PowerShell.TextUtility.
+        BeforeAll {
+            $mockSessions = 'USERNAME  SESSIONNAME  ID  STATE'
+            Mock -CommandName Get-Module -MockWith { $null } -ModuleName $env:BHProjectName
+            Mock -CommandName Invoke-Command -MockWith { $mockSessions } -ModuleName $env:BHProjectName
+        }
+
+        # The -ComputerName ValidateScript pings the target before the body runs, so this can
+        # only use localhost; localhost is in the function's self-reference list, which must
+        # route to local execution rather than New-PSSession.
+        It -Name 'treats localhost as the local system rather than opening a remote session' -Test {
+            Get-LoggedOnUser -ComputerName 'localhost' | Should -Be 'USERNAME  SESSIONNAME  ID  STATE'
+            Should -Invoke -CommandName Invoke-Command -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $null -eq $Session }
+        }
+    }
+}

--- a/Tests/Unit/Get-WinInfo.tests.ps1
+++ b/Tests/Unit/Get-WinInfo.tests.ps1
@@ -22,33 +22,4 @@ Describe -Name 'Get-WinInfo' -Fixture {
                 Should -Throw -ExpectedMessage '*requires Windows*'
         }
     }
-
-    Context -Name 'list mode (Windows only)' -Fixture {
-        It -Name 'returns the formatted class list without error' -Skip:(-not $IsWindows) -Test {
-            { Get-WinInfo -List } | Should -Not -Throw
-            Get-WinInfo -List | Should -Not -BeNullOrEmpty
-        }
-    }
-
-    Context -Name 'info mode (Windows only)' -Fixture {
-        # Get-CimInstance is mocked so no real WMI/CIM query runs; these tests verify the
-        # information model entry selected by -Id is translated into the right CIM parameters
-        BeforeAll {
-            Mock -CommandName Get-CimInstance -MockWith {
-                [PSCustomObject] @{ Name = 'MockedInstance' }
-            } -ModuleName $env:BHProjectName
-        }
-
-        It -Name 'queries the namespace and class selected by -Id' -Skip:(-not $IsWindows) -Test {
-            Get-WinInfo -Id 1 | Should -Not -BeNullOrEmpty
-            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
-                -ParameterFilter { $Namespace -eq 'root/CIMV2' -and $ClassName -eq 'cim_process' }
-        }
-
-        It -Name 'applies the class filter when the model defines one' -Skip:(-not $IsWindows) -Test {
-            Get-WinInfo -Id 4 | Out-Null
-            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
-                -ParameterFilter { $ClassName -eq 'win32_ntlogevent' -and $Filter -like '*logfile*' }
-        }
-    }
 }

--- a/Tests/Unit/Get-WinInfo.tests.windows.ps1
+++ b/Tests/Unit/Get-WinInfo.tests.windows.ps1
@@ -1,0 +1,37 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Get-WinInfo' -Fixture {
+
+    Context -Name 'list mode' -Fixture {
+        It -Name 'returns the formatted class list without error' -Test {
+            { Get-WinInfo -List } | Should -Not -Throw
+            Get-WinInfo -List | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context -Name 'info mode' -Fixture {
+        # Get-CimInstance is mocked so no real WMI/CIM query runs; these tests verify the
+        # information model entry selected by -Id is translated into the right CIM parameters.
+        BeforeAll {
+            Mock -CommandName Get-CimInstance -MockWith {
+                [PSCustomObject] @{ Name = 'MockedInstance' }
+            } -ModuleName $env:BHProjectName
+        }
+
+        It -Name 'queries the namespace and class selected by -Id' -Test {
+            Get-WinInfo -Id 1 | Should -Not -BeNullOrEmpty
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $Namespace -eq 'root/CIMV2' -and $ClassName -eq 'cim_process' }
+        }
+
+        It -Name 'applies the class filter when the model defines one' -Test {
+            Get-WinInfo -Id 4 | Out-Null
+            Should -Invoke -CommandName Get-CimInstance -ModuleName $env:BHProjectName -Times 1 -Exactly `
+                -ParameterFilter { $ClassName -eq 'win32_ntlogevent' -and $Filter -like '*logfile*' }
+        }
+    }
+}

--- a/Tests/Unit/Out-MeasureResult.tests.ps1
+++ b/Tests/Unit/Out-MeasureResult.tests.ps1
@@ -60,4 +60,19 @@ Describe -Name 'Out-MeasureResult' -Fixture {
             $viaParam.AvgMilliseconds | Should -Be $viaPipe.AvgMilliseconds
         }
     }
+
+    Context -Name 'tied measurements' -Fixture {
+        It -Name 'handles a collection where every TimeSpan has identical Ticks' -Test {
+            # Regression: a prior implementation used $list.Where({ $_.Ticks -eq $max })
+            # which returned a multi-element collection when all ticks tied, and the
+            # subsequent [System.Int32] cast on the member-enumerated TotalMilliseconds
+            # array silently failed — producing a null result.
+            $spans = @([TimeSpan]::Zero, [TimeSpan]::Zero, [TimeSpan]::Zero, [TimeSpan]::Zero)
+            $result = $spans | Out-MeasureResult
+            $result | Should -Not -BeNullOrEmpty
+            $result.MaxMilliseconds | Should -Be 0
+            $result.MinMilliseconds | Should -Be 0
+            $result.AvgMilliseconds | Should -Be 0
+        }
+    }
 }

--- a/Tests/Unit/Test-Performance.tests.ps1
+++ b/Tests/Unit/Test-Performance.tests.ps1
@@ -52,10 +52,7 @@ Describe -Name 'Test-Performance' -Fixture {
         }
 
         It -Name 'returns one measurement per iteration on the Measurements property' -Test {
-            # Use Start-Sleep so each iteration accumulates measurable, non-uniform Ticks.
-            # A trivial { 1 + 1 } block can measure as TimeSpan.Zero on fast Linux runners,
-            # which trips a latent edge case in Out-MeasureResult when all ticks tie.
-            $r = Test-Performance -ScriptBlock { Start-Sleep -Milliseconds 1 } -Iterations 4
+            $r = Test-Performance -ScriptBlock { 1 + 1 } -Iterations 4
             $r.Measurements | Should -HaveCount 4
         }
 

--- a/Tests/Unit/Test-Performance.tests.ps1
+++ b/Tests/Unit/Test-Performance.tests.ps1
@@ -52,7 +52,10 @@ Describe -Name 'Test-Performance' -Fixture {
         }
 
         It -Name 'returns one measurement per iteration on the Measurements property' -Test {
-            $r = Test-Performance -ScriptBlock { 1 + 1 } -Iterations 4
+            # Use Start-Sleep so each iteration accumulates measurable, non-uniform Ticks.
+            # A trivial { 1 + 1 } block can measure as TimeSpan.Zero on fast Linux runners,
+            # which trips a latent edge case in Out-MeasureResult when all ticks tie.
+            $r = Test-Performance -ScriptBlock { Start-Sleep -Milliseconds 1 } -Iterations 4
             $r.Measurements | Should -HaveCount 4
         }
 

--- a/Tests/Unit/Test-Performance.tests.ps1
+++ b/Tests/Unit/Test-Performance.tests.ps1
@@ -1,0 +1,67 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Test-Performance' -Fixture {
+
+    Context -Name 'command metadata' -Fixture {
+        BeforeAll {
+            $script:Cmd = Get-Command -Name 'Test-Performance' -Module $env:BHProjectName
+        }
+
+        It -Name 'is exported by the module' -Test {
+            $script:Cmd | Should -Not -BeNullOrEmpty
+        }
+
+        It -Name 'declares -ScriptBlock as mandatory' -Test {
+            $script:Cmd.Parameters['ScriptBlock'].Attributes.Mandatory | Should -Contain $true
+        }
+
+        It -Name 'declares -Iterations with the Runs alias' -Test {
+            $script:Cmd.Parameters['Iterations'].Aliases | Should -Contain 'Runs'
+        }
+
+        It -Name 'defaults -Iterations to 10' -Test {
+            # The default lives in the param() block; binding without -Iterations exercises it.
+            $r = Test-Performance -ScriptBlock { 1 + 1 }
+            $r.Measurements.Count | Should -Be 10
+        }
+    }
+
+    Context -Name 'parameter validation' -Fixture {
+        It -Name 'rejects -Iterations below the ValidateRange minimum (3)' -Test {
+            { Test-Performance -ScriptBlock { 1 + 1 } -Iterations 2 } | Should -Throw
+        }
+
+        It -Name 'rejects -Iterations above the ValidateRange maximum (10000)' -Test {
+            { Test-Performance -ScriptBlock { 1 + 1 } -Iterations 10001 } | Should -Throw
+        }
+
+        It -Name 'rejects a null -ScriptBlock' -Test {
+            { Test-Performance -ScriptBlock $null -Iterations 3 } | Should -Throw
+        }
+    }
+
+    Context -Name 'execution' -Fixture {
+        It -Name 'runs the script block exactly -Iterations times' -Test {
+            $script:counter = 0
+            $null = Test-Performance -ScriptBlock { $script:counter++ } -Iterations 3
+            $script:counter | Should -Be 3
+        }
+
+        It -Name 'returns one measurement per iteration on the Measurements property' -Test {
+            $r = Test-Performance -ScriptBlock { 1 + 1 } -Iterations 4
+            $r.Measurements | Should -HaveCount 4
+        }
+
+        It -Name 'returns Min/Max/Avg millisecond statistics from Out-MeasureResult' -Test {
+            $r = Test-Performance -ScriptBlock { Start-Sleep -Milliseconds 1 } -Iterations 3
+            foreach ($prop in 'MinMilliseconds', 'MaxMilliseconds', 'AvgMilliseconds') {
+                $r.PSObject.Properties.Name | Should -Contain $prop
+            }
+            $r.MaxMilliseconds | Should -BeGreaterOrEqual $r.MinMilliseconds
+        }
+    }
+}

--- a/Tests/Unit/Uninstall-MSI.tests.ps1
+++ b/Tests/Unit/Uninstall-MSI.tests.ps1
@@ -63,12 +63,4 @@ Describe -Name 'Uninstall-MSI' -Fixture {
             Should -Throw -ExpectedMessage '*requires Windows*'
         }
     }
-
-    Context -Name 'happy path (Windows only)' -Fixture {
-        It -Name 'reports "Application... not found" when no registry entry matches the GUID' -Skip:(-not $IsWindows) -Test {
-            # Use a GUID that is overwhelmingly unlikely to be installed
-            $result = Uninstall-MSI -ProductId 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'
-            $result | Should -Match 'not found'
-        }
-    }
 }

--- a/Tests/Unit/Uninstall-MSI.tests.windows.ps1
+++ b/Tests/Unit/Uninstall-MSI.tests.windows.ps1
@@ -1,0 +1,16 @@
+BeforeDiscovery {
+    if (-not (Get-Module -Name $env:BHProjectName)) {
+        Import-Module -Name $env:BHPSModuleManifest -ErrorAction 'Stop' -Force
+    }
+}
+
+Describe -Name 'Uninstall-MSI' -Fixture {
+
+    Context -Name 'happy path' -Fixture {
+        It -Name 'reports "Application... not found" when no registry entry matches the GUID' -Test {
+            # Use a GUID that is overwhelmingly unlikely to be installed
+            $result = Uninstall-MSI -ProductId 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF'
+            $result | Should -Match 'not found'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three related changes:

1. **D8 test coverage** — final slice of the audit (refs #109): Pester coverage for `Test-Performance`, the last public function without a dedicated test file.
2. **CI test split by OS scope** — the validate workflow now runs cross-platform tests on `ubuntu-latest` and Windows-only tests on `windows-latest`, eliminating the duplicate windows-latest run of the cross-platform suite.
3. **Out-MeasureResult tied-Ticks fix** — surfaced while wiring up the D8 tests on Linux CI; root-caused and patched in this PR rather than deferred.

## D8 coverage added

| Function | What is covered |
|---|---|
| `Test-Performance` | metadata (mandatory `-ScriptBlock`, `Runs` alias on `-Iterations`, default iterations = 10); `-Iterations` `[ValidateRange(3, 10000)]` enforcement (below/above); null `-ScriptBlock` rejection; iteration count drives execution via a script-block side-effect counter; one entry per iteration on the `Measurements` collection; `Min/Max/Avg` millisecond statistics surfaced from `Out-MeasureResult` |

## CI / build changes

- `Build/build.psake.ps1` — new `$PesterScope` property (default `'All'`) with three values:
  - `All` — cross-platform `.tests.ps1` + (on Windows) Windows-only `.tests.windows.ps1`. Preserves existing local-dev behavior.
  - `CrossPlatform` — only `.tests.ps1`.
  - `WindowsOnly` — only `.tests.windows.ps1`.

  Test discovery moved from the `Properties` block into the `Test` task itself so `Invoke-psake -properties` / `build.ps1 -Properties` overrides take effect.
- `.github/workflows/validate.yml` — matrix updated to `include` per-OS `pesterScope`: `ubuntu-latest` → `CrossPlatform`, `windows-latest` → `WindowsOnly`. The Test step now passes `-Properties @{ PesterScope = '${{ matrix.pesterScope }}' }`.

## Test file migration (companion to the split)

To make the split meaningful — without silently dropping coverage — every windows-gated `It` block previously living in a `.tests.ps1` file (the 12 `-Skip:(-not $IsWindows)` blocks across 7 files) was moved into its `.tests.windows.ps1` counterpart, with the `-Skip` guard dropped since file discovery now provides the gating. Inverse `-Skip:$IsWindows` blocks (the non-Windows platform-guard tests) stay in the cross-platform files where they belong.

New companion files (each lifted, not net-new coverage):

- `Find-LANHost.tests.windows.ps1`
- `Find-ServerPendingReboot.tests.windows.ps1`
- `Get-ActiveGatewayUser.tests.windows.ps1`
- `Get-AlternateDataStream.tests.windows.ps1`
- `Get-LoggedOnUser.tests.windows.ps1`
- `Get-WinInfo.tests.windows.ps1`
- `Uninstall-MSI.tests.windows.ps1`

Net effect on coverage:
- **Linux CI** — drops 12 `Skipped` lines that previously appeared in the report; runs the same 1058 cross-platform tests.
- **Windows CI** — runs the 21 `.tests.windows.ps1` tests (the 12 just-migrated + the 9 already in `Find-WinEvent.tests.windows.ps1` and `Get-Software.tests.windows.ps1`). Functionally identical to the windows-latest behavior of the old workflow, but no longer re-runs the cross-platform suite.

## Out-MeasureResult tied-Ticks fix

While wiring up the D8 test for `Test-Performance.Measurements`, the assertion failed on `ubuntu-latest` even though it passed on `windows-latest` and macOS. Root cause: a latent bug in `Out-MeasureResult.ps1`.

**The bug.** The `End` block computed scalar `$max`/`$min` via `Measure-Object -Property Ticks`, then re-derived the matching `TimeSpan` *object* with:

```powershell
$maxObj = $list.Where( { $_.Ticks -eq $max } )
$minObj = $list.Where( { $_.Ticks -eq $min } )
...
MaxMilliseconds = [System.Int32] $maxObj.TotalMilliseconds
```

When every measurement tied on `Ticks` (common when the probed scriptblock measures as `TimeSpan.Zero` on a fast Linux runner), `.Where()` returned the full multi-element collection, the subsequent `[System.Int32]` cast on the member-enumerated `TotalMilliseconds` array silently failed, and the function returned `$null`. Callers like `Test-Performance` then had no `Measurements` NoteProperty to read.

**The fix.** Collapse the `End` block to a single `Measure-Object -Property TotalMilliseconds -Maximum -Minimum -Average`. No `.Where()`, no tied-Ticks edge case, and Max/Min/Avg now all derive from the same property — removing a latent rounding mismatch between Ticks-based max/min and TotalMilliseconds-based avg.

**Regression test.** Added a new `tied measurements` context in `Out-MeasureResult.tests.ps1` that pipes four `TimeSpan.Zero` values and asserts a non-null PSCustomObject with `Max`/`Min`/`Avg` all equal to `0`.

## Notes

- Compare-List deepening (Group C in the audit) was already addressed in #110 (empty arrays, single-item lists, 1-col / 3-col CSV) — the umbrella checklist just wasn't ticked. I'll update it on merge.
- Local default (`./Build/build.ps1 -TaskList Test, Cleanup`) on macOS: 1059 passed / 1 skipped / 0 failed. The 1 skip is the existing `Get-ADUserStatus` ActiveDirectory-module guard, unrelated to this change.
- Local `WindowsOnly` on macOS discovers all 21 tests; 18 fail because they assume a Windows runtime — that's by design and matches what `Find-WinEvent.tests.windows.ps1` / `Get-Software.tests.windows.ps1` already did. They pass on the windows-latest CI runner.
- After merge, every public function in `SecurityTools.psd1` has a dedicated test file — the audit's acceptance criterion is met and #109 can be closed.
