### PR TITLE
ci: surface Pester results inline via dorny/test-reporter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
           - os: windows-latest
             pesterScope: WindowsOnly
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -44,3 +47,12 @@ jobs:
           name: Pester Results (${{ matrix.os }})
           path: "Artifacts/**/Test-*.xml"
           if-no-files-found: error
+
+      - name: Publish Pester results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: always()
+        with:
+          name: Pester Tests (${{ matrix.os }})
+          path: Artifacts/**/Test-*.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/Build/build.psake.ps1
+++ b/Build/build.psake.ps1
@@ -166,7 +166,7 @@ Task 'Test' -depends 'ImportStagingModule' {
 
     # create a new configuration with our settings
     $PesterConfig = New-PesterConfiguration
-    $PesterConfig.TestResult.OutputFormat = 'NUnitXML'
+    $PesterConfig.TestResult.OutputFormat = 'JUnitXml'
     $PesterConfig.TestResult.OutputPath = $TestFilePath
     $PesterConfig.TestResult.Enabled = $true
     $PesterConfig.Run.PassThru = $true


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `dorny/test-reporter` (SHA-pinned to v3.0.0) to `validate.yml` so Pester failures surface as inline Check Run annotations on PRs rather than requiring artifact downloads
- Switches Pester output format from `NUnitXML` to `JUnitXml` — NUnit v2.5 causes parsing errors in the reporter (same finding as johnsarie27/PS.SSL#47)
- Adds minimal `permissions` block (`contents: read`, `checks: write`) to the validate job; `pull-requests: write` intentionally excluded per security review
- Check Run name includes `${{ matrix.os }}` to produce distinct annotations for each matrix leg (ubuntu / windows)

Closes #124

## Test plan

- [ ] Open a draft PR and deliberately break a Pester test — confirm inline annotation appears in the Check Run for both matrix legs
- [ ] Confirm artifact upload still works (raw XML still available)
- [ ] Confirm a passing run does not produce a failing Check Run (`fail-on-error: false`)

https://claude.ai/code/session_01CfzpixQdYorvMZRmgL2zMc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfzpixQdYorvMZRmgL2zMc)_